### PR TITLE
fix day number (remove day unit string) in menu icon

### DIFF
--- a/Moon/ViewController.m
+++ b/Moon/ViewController.m
@@ -382,15 +382,22 @@
 
 - (NSString *)iconText
 {
-    NSMutableString *template = @"d".mutableCopy;
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:kShowMonthInIcon]) {
-        [template appendString:@"MMM"];
+    NSString *iconText;
+    
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:kShowMonthInIcon] || [[NSUserDefaults standardUserDefaults] boolForKey:kShowDayOfWeekInIcon]) {
+        NSMutableString *template = @"d".mutableCopy;
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:kShowMonthInIcon]) {
+            [template appendString:@"MMM"];
+        }
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:kShowDayOfWeekInIcon]) {
+            [template appendString:@"EEE"];
+        }
+        [_iconDateFormatter setDateFormat:[NSDateFormatter dateFormatFromTemplate:template options:0 locale:[NSLocale currentLocale]]];
+        iconText = [_iconDateFormatter stringFromDate:[NSDate new]];
+    } else {
+        iconText = [NSString stringWithFormat:@"%zd", _moCal.todayDate.day];
     }
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:kShowDayOfWeekInIcon]) {
-        [template appendString:@"EEE"];
-    }
-    [_iconDateFormatter setDateFormat:[NSDateFormatter dateFormatFromTemplate:template options:0 locale:[NSLocale currentLocale]]];
-    NSString *iconText = [_iconDateFormatter stringFromDate:[NSDate new]];
+    
     if (iconText == nil) {
         iconText = @"!!";
     }


### PR DESCRIPTION
in 0.10.11, date format will add day unit string in Chinese (or maybe other languages, too)

![2016-04-19 11 53 12](https://cloud.githubusercontent.com/assets/88617/14628018/92c4f192-062c-11e6-80db-5dcc487e0abf.png)

so I copy some old codes back to ensure there only day number will show up when kShowMonthInIcon and kShowDayOfWeekInIcon are false