### PR TITLE
Theme option

### DIFF
--- a/Itsycal.xcodeproj/project.pbxproj
+++ b/Itsycal.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		71E66A261EED92A700871F44 /* ItsyColors.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E66A251EED92A700871F44 /* ItsyColors.m */; };
 		9215AD4C1E3AECA700317FAE /* MoVFLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9215AD4B1E3AECA700317FAE /* MoVFLHelper.m */; };
 		921E62CD1E26B3EA007B029F /* PrefsGeneralVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 921E62C11E26B3EA007B029F /* PrefsGeneralVC.m */; };
 		921E62D01E26B9D2007B029F /* PrefsAppearanceVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 921E62CF1E26B9D2007B029F /* PrefsAppearanceVC.m */; };
@@ -61,6 +62,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		71E66A241EED92A700871F44 /* ItsyColors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ItsyColors.h; sourceTree = "<group>"; };
+		71E66A251EED92A700871F44 /* ItsyColors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ItsyColors.m; sourceTree = "<group>"; };
 		9215AD4A1E3AECA700317FAE /* MoVFLHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MoVFLHelper.h; sourceTree = "<group>"; };
 		9215AD4B1E3AECA700317FAE /* MoVFLHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MoVFLHelper.m; sourceTree = "<group>"; };
 		921E62C01E26B3EA007B029F /* PrefsGeneralVC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrefsGeneralVC.h; sourceTree = "<group>"; };
@@ -205,6 +208,8 @@
 				929223E91E2D6E0800F1A119 /* HighlightPicker.h */,
 				929223EA1E2D6E0800F1A119 /* HighlightPicker.m */,
 				922232CB1A8DF672003BFAD9 /* EventCenter.h */,
+				71E66A241EED92A700871F44 /* ItsyColors.h */,
+				71E66A251EED92A700871F44 /* ItsyColors.m */,
 				922232CC1A8DF672003BFAD9 /* EventCenter.m */,
 				92CDDE791A955D7F00D7675C /* AgendaViewController.h */,
 				92CDDE7A1A955D7F00D7675C /* AgendaViewController.m */,
@@ -297,7 +302,6 @@
 				TargetAttributes = {
 					9242A55B1A82A136005AA4B3 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = HFT3T55WND;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -351,6 +355,7 @@
 				9242A5651A82A136005AA4B3 /* main.m in Sources */,
 				9278CADB1A990462004B6BB9 /* MoTableView.m in Sources */,
 				929223EB1E2D6E0900F1A119 /* HighlightPicker.m in Sources */,
+				71E66A261EED92A700871F44 /* ItsyColors.m in Sources */,
 				925B47181A93B63100E0329A /* MoCalToolTipWC.m in Sources */,
 				9242A5871A82A1A1005AA4B3 /* ItsycalWindow.m in Sources */,
 				92CDDE7B1A955D7F00D7675C /* AgendaViewController.m in Sources */,
@@ -432,7 +437,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -478,7 +483,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -501,9 +506,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = HFT3T55WND;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Itsycal/_frameworks",
@@ -520,10 +525,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = HFT3T55WND;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Itsycal/_frameworks",

--- a/Itsycal/AgendaViewController.h
+++ b/Itsycal/AgendaViewController.h
@@ -8,6 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 #import "MoTableView.h"
+#import "ItsyColors.h"
 
 @protocol AgendaDelegate;
 

--- a/Itsycal/AgendaViewController.m
+++ b/Itsycal/AgendaViewController.m
@@ -51,8 +51,8 @@ static NSString *kEventCellIdentifier = @"EventCell";
     _tv.headerView = nil;
     _tv.allowsColumnResizing = NO;
     _tv.intercellSpacing = NSMakeSize(0, 0);
-    _tv.backgroundColor = [NSColor whiteColor];
-    _tv.hoverColor = [NSColor secondarySelectedControlColor];
+    _tv.backgroundColor = [ItsyColors getPrimaryBackgroundColor];
+    _tv.hoverColor = [ItsyColors getSecondaryBackgroundColor];
     _tv.floatsGroupRows = YES;
     _tv.refusesFirstResponder = YES;
     _tv.dataSource = self;
@@ -288,7 +288,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     }
     NSString *string = [NSString stringWithFormat:@"%@%@", title, duration];
     NSMutableAttributedString *s = [[NSMutableAttributedString alloc] initWithString:string];
-    [s addAttributes:@{NSForegroundColorAttributeName: [NSColor labelColor]} range:NSMakeRange(0, title.length)];
+    [s addAttributes:@{NSForegroundColorAttributeName: [ItsyColors getPrimaryTextColor]} range:NSMakeRange(0, title.length)];
     return s;
 }
 
@@ -311,7 +311,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
         _textField = [NSTextField new];
         _textField.translatesAutoresizingMaskIntoConstraints = NO;
         _textField.font = [NSFont systemFontOfSize:11 weight:NSFontWeightSemibold];
-        _textField.textColor = [NSColor labelColor];
+        _textField.textColor = [ItsyColors getPrimaryTextColor];
         _textField.editable = NO;
         _textField.bezeled = NO;
         _textField.drawsBackground = NO;
@@ -326,11 +326,11 @@ static NSString *kEventCellIdentifier = @"EventCell";
 - (void)drawRect:(NSRect)dirtyRect
 {
     NSRect r = self.bounds;
-    [[NSColor controlBackgroundColor] set];
+    [[ItsyColors getPrimaryBackgroundColor] set];
     NSRectFillUsingOperation(r, NSCompositingOperationSourceOver);
 
     r.size.height -= 1;
-    [[NSColor controlBackgroundColor] set];
+    [[ItsyColors getPrimaryBackgroundColor] set];
     NSRectFillUsingOperation(r, NSCompositingOperationSourceOver);
 }
 
@@ -350,7 +350,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
         _textField = [NSTextField new];
         _textField.translatesAutoresizingMaskIntoConstraints = NO;
         _textField.font = [NSFont systemFontOfSize:11];
-        _textField.textColor = [NSColor labelColor];
+        _textField.textColor = [ItsyColors getPrimaryTextColor];
         _textField.lineBreakMode = NSLineBreakByWordWrapping;
         _textField.editable = NO;
         _textField.bezeled = NO;
@@ -358,7 +358,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
         _textField.stringValue = @"";
         _btnDelete = [MoButton new];
         _btnDelete.image = [NSImage imageNamed:@"btnDel"];
-        _btnDelete.backgroundColor = [NSColor controlBackgroundColor];
+        _btnDelete.backgroundColor = [ItsyColors getPrimaryBackgroundColor];
         [self addSubview:_textField];
         [self addSubview:_btnDelete];
         [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-16-[_textField]-8-|" options:0 metrics:nil views:@{@"_textField": _textField}]];
@@ -387,10 +387,10 @@ static NSString *kEventCellIdentifier = @"EventCell";
 - (void)drawRect:(NSRect)dirtyRect
 {
     // Draw a colored circle with a slightly darker border.
-    [[self.eventInfo.event.calendar.color blendedColorWithFraction:0.1 ofColor:[NSColor blackColor]] set];
+    [[self.eventInfo.event.calendar.color blendedColorWithFraction:0.1 ofColor:[ItsyColors getBorderColor]] set];
     NSRect circleRect = NSMakeRect(4, NSMaxY(self.frame)-14, 8, 8);
     [[NSBezierPath bezierPathWithOvalInRect:circleRect] fill];
-    [[self.eventInfo.event.calendar.color blendedColorWithFraction:0.5 ofColor:[NSColor whiteColor]] set];
+    [[self.eventInfo.event.calendar.color blendedColorWithFraction:0.5 ofColor:[ItsyColors getBorderColor]] set];
     circleRect = NSInsetRect(circleRect, 1, 1);
     [[NSBezierPath bezierPathWithOvalInRect:circleRect] fill];
 }

--- a/Itsycal/AgendaViewController.m
+++ b/Itsycal/AgendaViewController.m
@@ -52,7 +52,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     _tv.allowsColumnResizing = NO;
     _tv.intercellSpacing = NSMakeSize(0, 0);
     _tv.backgroundColor = [NSColor whiteColor];
-    _tv.hoverColor = [NSColor colorWithWhite:0.98 alpha:1];
+    _tv.hoverColor = [NSColor secondarySelectedControlColor];
     _tv.floatsGroupRows = YES;
     _tv.refusesFirstResponder = YES;
     _tv.dataSource = self;
@@ -288,7 +288,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     }
     NSString *string = [NSString stringWithFormat:@"%@%@", title, duration];
     NSMutableAttributedString *s = [[NSMutableAttributedString alloc] initWithString:string];
-    [s addAttributes:@{NSForegroundColorAttributeName: [NSColor blackColor]} range:NSMakeRange(0, title.length)];
+    [s addAttributes:@{NSForegroundColorAttributeName: [NSColor labelColor]} range:NSMakeRange(0, title.length)];
     return s;
 }
 
@@ -311,7 +311,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
         _textField = [NSTextField new];
         _textField.translatesAutoresizingMaskIntoConstraints = NO;
         _textField.font = [NSFont systemFontOfSize:11 weight:NSFontWeightSemibold];
-        _textField.textColor = [NSColor colorWithWhite:0 alpha:0.9];
+        _textField.textColor = [NSColor labelColor];
         _textField.editable = NO;
         _textField.bezeled = NO;
         _textField.drawsBackground = NO;
@@ -326,11 +326,11 @@ static NSString *kEventCellIdentifier = @"EventCell";
 - (void)drawRect:(NSRect)dirtyRect
 {
     NSRect r = self.bounds;
-    [[NSColor colorWithWhite:0.86 alpha:1] set];
+    [[NSColor controlBackgroundColor] set];
     NSRectFillUsingOperation(r, NSCompositingOperationSourceOver);
 
     r.size.height -= 1;
-    [[NSColor colorWithWhite:0.95 alpha:1] set];
+    [[NSColor controlBackgroundColor] set];
     NSRectFillUsingOperation(r, NSCompositingOperationSourceOver);
 }
 
@@ -350,7 +350,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
         _textField = [NSTextField new];
         _textField.translatesAutoresizingMaskIntoConstraints = NO;
         _textField.font = [NSFont systemFontOfSize:11];
-        _textField.textColor = [NSColor colorWithWhite:0.5 alpha:1];
+        _textField.textColor = [NSColor labelColor];
         _textField.lineBreakMode = NSLineBreakByWordWrapping;
         _textField.editable = NO;
         _textField.bezeled = NO;
@@ -358,7 +358,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
         _textField.stringValue = @"";
         _btnDelete = [MoButton new];
         _btnDelete.image = [NSImage imageNamed:@"btnDel"];
-        _btnDelete.backgroundColor = [NSColor colorWithDeviceWhite:0.98 alpha:1];
+        _btnDelete.backgroundColor = [NSColor controlBackgroundColor];
         [self addSubview:_textField];
         [self addSubview:_btnDelete];
         [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-16-[_textField]-8-|" options:0 metrics:nil views:@{@"_textField": _textField}]];

--- a/Itsycal/AppDelegate.m
+++ b/Itsycal/AppDelegate.m
@@ -12,6 +12,7 @@
 #import "ViewController.h"
 #import "MASShortcut/MASShortcutBinder.h"
 #import "MASShortcut/MASShortcutMonitor.h"
+#import "ItsyColors.h"
 
 @implementation AppDelegate
 {
@@ -30,7 +31,8 @@
         kWeekStartDOW:         @0, // Sun=0, Mon=1,... (MoCalendar.h)
         kShowMonthInIcon:      @(NO),
         kShowDayOfWeekInIcon:  @(NO),
-        kHideIcon:             @(NO)
+        kHideIcon:             @(NO),
+        kThemeName:             [NSNumber numberWithInt: TDefault]
     }];
     
     // Constrain kShowEventDays to values 0...7 in (unlikely) case it is invalid.

--- a/Itsycal/ItsyColors.h
+++ b/Itsycal/ItsyColors.h
@@ -1,0 +1,25 @@
+//
+//  ItsyColors.h
+//  Itsycal
+//
+//  Created by Ale on 11/06/17.
+//  Copyright © 2017 mowglii.com. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+
+@interface ItsyColors : NSObject
+
++ (NSColor *) getPrimaryTextColor;
++ (NSColor *) getSecondaryTextColor;
++ (NSColor *) getPrimaryBackgroundColor;
++ (NSColor *) getSecondaryBackgroundColor;
++ (NSColor *) getBorderColor;
++ (NSColor *) getHighlightColor;
++ (NSColor *) getHoverColor;
++ (NSColor *) getShadowColor;
+
++ (NSAppearance *) getAppearance;
+
+@end

--- a/Itsycal/ItsyColors.h
+++ b/Itsycal/ItsyColors.h
@@ -6,10 +6,15 @@
 //  Copyright © 2017 mowglii.com. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import <Cocoa/Cocoa.h>
+#import "Itsycal.h"
 
 @interface ItsyColors : NSObject
+
+typedef NS_OPTIONS(NSInteger, ItsyThemes){
+    TDefault = 0,
+    TLight = 1,
+    TDark = 2
+};
 
 + (NSColor *) getPrimaryTextColor;
 + (NSColor *) getSecondaryTextColor;
@@ -21,5 +26,6 @@
 + (NSColor *) getShadowColor;
 
 + (NSAppearance *) getAppearance;
++ (BOOL)allowsVibrancy;
 
 @end

--- a/Itsycal/ItsyColors.m
+++ b/Itsycal/ItsyColors.m
@@ -25,7 +25,7 @@
 + (NSColor *) getSecondaryTextColor{
     switch ([self curTheme]) {
         case TDefault:
-            return [NSColor grayColor];
+            return [NSColor colorWithRed:0.51 green:0.51 blue:0.51 alpha:1];
             break;
         case TLight:
         case TDark:
@@ -49,7 +49,7 @@
 + (NSColor *) getSecondaryBackgroundColor{
     switch ([self curTheme]) {
         case TDefault:
-            return [NSColor lightGrayColor];
+            return [NSColor colorWithRed:0.95 green:0.95 blue:0.95 alpha:1];
             break;
         case TLight:
         case TDark:
@@ -61,7 +61,7 @@
 + (NSColor *) getBorderColor{
     switch ([self curTheme]) {
         case TDefault:
-            return [NSColor blackColor];
+            return [NSColor colorWithWhite:0 alpha:0.25];
             break;
         case TLight:
         case TDark:
@@ -73,7 +73,7 @@
 + (NSColor *) getHighlightColor{
     switch ([self curTheme]) {
         case TDefault:
-            return [NSColor blueColor];
+            return [NSColor colorWithRed:0.4 green:0.6 blue:1 alpha:1];
             break;
         case TLight:
         case TDark:
@@ -85,7 +85,7 @@
 + (NSColor *) getHoverColor{
     switch ([self curTheme]) {
         case TDefault:
-            return [NSColor blueColor];
+            return [NSColor colorWithRed:0.2 green:0.2 blue:0.3 alpha:0.2];
             break;
         case TLight:
         case TDark:
@@ -97,7 +97,7 @@
 + (NSColor *) getShadowColor{
     switch ([self curTheme]) {
         case TDefault:
-            return [NSColor blackColor];
+            return [NSColor colorWithWhite:0 alpha:0.2];
             break;
         case TLight:
         case TDark:
@@ -109,7 +109,7 @@
 + (NSAppearance *) getAppearance{
     switch ([self curTheme]) {
         case TDefault:
-            return nil;
+            return [NSAppearance appearanceNamed:@"NSAppearanceNameAqua"];
             break;
         case TLight:
             return [NSAppearance appearanceNamed:@"NSAppearanceNameVibrantLight"];

--- a/Itsycal/ItsyColors.m
+++ b/Itsycal/ItsyColors.m
@@ -1,0 +1,49 @@
+//
+//  ItsyColors.m
+//  Itsycal
+//
+//  Created by Ale on 11/06/17.
+//  Copyright © 2017 mowglii.com. All rights reserved.
+//
+
+#import "ItsyColors.h"
+
+@implementation ItsyColors
+
++ (NSColor *) getPrimaryTextColor{
+    return [NSColor textColor];
+}
+
++ (NSColor *) getSecondaryTextColor{
+    return [NSColor secondaryLabelColor];
+}
+
++ (NSColor *) getPrimaryBackgroundColor{
+    return [NSColor controlBackgroundColor];
+}
+
++ (NSColor *) getSecondaryBackgroundColor{
+    return [NSColor windowBackgroundColor];
+}
+
++ (NSColor *) getBorderColor{
+    return [NSColor scrollBarColor];
+}
+
++ (NSColor *) getHighlightColor{
+    return [NSColor alternateSelectedControlColor];
+}
+
++ (NSColor *) getHoverColor{
+    return [NSColor alternateSelectedControlTextColor];
+}
+
++ (NSColor *) getShadowColor{
+    return [NSColor clearColor];
+}
+
++ (NSAppearance *) getAppearance{
+    return [NSAppearance appearanceNamed:@"NSAppearanceNameVibrantDark"];
+}
+
+@end

--- a/Itsycal/ItsyColors.m
+++ b/Itsycal/ItsyColors.m
@@ -11,39 +11,129 @@
 @implementation ItsyColors
 
 + (NSColor *) getPrimaryTextColor{
-    return [NSColor textColor];
+    switch ([self curTheme]) {
+        case TDefault:
+            return [NSColor blackColor];
+            break;
+        case TLight:
+        case TDark:
+            return [NSColor textColor];
+            break;
+    }
 }
 
 + (NSColor *) getSecondaryTextColor{
-    return [NSColor secondaryLabelColor];
+    switch ([self curTheme]) {
+        case TDefault:
+            return [NSColor grayColor];
+            break;
+        case TLight:
+        case TDark:
+            return [NSColor secondaryLabelColor];
+            break;
+    }
 }
 
 + (NSColor *) getPrimaryBackgroundColor{
-    return [NSColor controlBackgroundColor];
+    switch ([self curTheme]) {
+        case TDefault:
+            return [NSColor whiteColor];
+            break;
+        case TLight:
+        case TDark:
+            return [NSColor controlBackgroundColor];
+            break;
+    }
 }
 
 + (NSColor *) getSecondaryBackgroundColor{
-    return [NSColor windowBackgroundColor];
+    switch ([self curTheme]) {
+        case TDefault:
+            return [NSColor lightGrayColor];
+            break;
+        case TLight:
+        case TDark:
+            return [NSColor windowBackgroundColor];
+            break;
+    }
 }
 
 + (NSColor *) getBorderColor{
-    return [NSColor scrollBarColor];
+    switch ([self curTheme]) {
+        case TDefault:
+            return [NSColor blackColor];
+            break;
+        case TLight:
+        case TDark:
+            return [NSColor scrollBarColor];
+            break;
+    }
 }
 
 + (NSColor *) getHighlightColor{
-    return [NSColor alternateSelectedControlColor];
+    switch ([self curTheme]) {
+        case TDefault:
+            return [NSColor blueColor];
+            break;
+        case TLight:
+        case TDark:
+            return [NSColor alternateSelectedControlColor];
+            break;
+    }
 }
 
 + (NSColor *) getHoverColor{
-    return [NSColor alternateSelectedControlTextColor];
+    switch ([self curTheme]) {
+        case TDefault:
+            return [NSColor blueColor];
+            break;
+        case TLight:
+        case TDark:
+            return [NSColor alternateSelectedControlColor];
+            break;
+    }
 }
 
 + (NSColor *) getShadowColor{
-    return [NSColor clearColor];
+    switch ([self curTheme]) {
+        case TDefault:
+            return [NSColor blackColor];
+            break;
+        case TLight:
+        case TDark:
+            return [NSColor clearColor];
+            break;
+    }
 }
 
 + (NSAppearance *) getAppearance{
-    return [NSAppearance appearanceNamed:@"NSAppearanceNameVibrantDark"];
+    switch ([self curTheme]) {
+        case TDefault:
+            return nil;
+            break;
+        case TLight:
+            return [NSAppearance appearanceNamed:@"NSAppearanceNameVibrantLight"];
+            break;
+        case TDark:
+            return [NSAppearance appearanceNamed:@"NSAppearanceNameVibrantDark"];
+            break;
+    }
+}
+
++ (BOOL)allowsVibrancy{
+    switch ([self curTheme]) {
+        case TDefault:
+            return NO;
+            break;
+        case TLight:
+        case TDark:
+            return YES;
+            break;
+    }
+}
+
++ (ItsyThemes) curTheme{
+    return [[NSUserDefaults standardUserDefaults] integerForKey:kThemeName];
 }
 
 @end

--- a/Itsycal/Itsycal.h
+++ b/Itsycal/Itsycal.h
@@ -23,3 +23,4 @@ extern NSString * const kShowDayOfWeekInIcon;
 extern NSString * const kAllowOutsideApplicationsFolder;
 extern NSString * const kClockFormat;
 extern NSString * const kHideIcon;
+extern NSString * const kThemeName;

--- a/Itsycal/Itsycal.m
+++ b/Itsycal/Itsycal.m
@@ -7,6 +7,7 @@
 //
 
 #import "Itsycal.h"
+#import "ItsyColors.h"
 
 // NSUserDefaults keys
 NSString * const kPinItsycal = @"PinItsycal";
@@ -21,3 +22,4 @@ NSString * const kShowDayOfWeekInIcon = @"ShowDayOfWeekInIcon";
 NSString * const kAllowOutsideApplicationsFolder = @"AllowOutsideApplicationsFolder";
 NSString * const kClockFormat = @"ClockFormat";
 NSString * const kHideIcon = @"HideIcon";
+NSString * const kThemeName = @"ThemeName";

--- a/Itsycal/ItsycalWindow.h
+++ b/Itsycal/ItsycalWindow.h
@@ -7,6 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import "ItsyColors.h"
 
 @interface ItsycalWindow : NSPanel
 

--- a/Itsycal/ItsycalWindow.m
+++ b/Itsycal/ItsycalWindow.m
@@ -37,8 +37,7 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth + kShado
 {
     self = [super initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskNonactivatingPanel backing:NSBackingStoreBuffered defer:NO];
     if (self) {
-        [self setAppearance:[NSAppearance appearanceNamed:@"NSAppearanceNameVibrantDark"]];
-        //[NSAppearance appearanceNamed:@"NSAppearanceNameVibrantLight"]
+        [self setAppearance:[ItsyColors getAppearance]];
         [self setBackgroundColor:[NSColor clearColor]];
         [self setOpaque:NO];
         [self setLevel:NSMainMenuWindowLevel];
@@ -198,7 +197,7 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth + kShado
     }
     [shadow set];*/
     //[[NSColor colorWithWhite:0.3 alpha:0.4] setStroke];
-    [[NSColor controlBackgroundColor] setFill];
+    [[ItsyColors getPrimaryBackgroundColor] setFill];
     [rectPath setLineWidth:2*kBorderWidth];
     [rectPath stroke];
     [rectPath fill];

--- a/Itsycal/ItsycalWindow.m
+++ b/Itsycal/ItsycalWindow.m
@@ -37,7 +37,7 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth + kShado
 {
     self = [super initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskNonactivatingPanel backing:NSBackingStoreBuffered defer:NO];
     if (self) {
-        [self setAppearance:[NSAppearance appearanceNamed:@"NSAppearanceNameVibrantLight"]];
+        [self setAppearance:[NSAppearance appearanceNamed:@"NSAppearanceNameVibrantDark"]];
         //[NSAppearance appearanceNamed:@"NSAppearanceNameVibrantLight"]
         [self setBackgroundColor:[NSColor clearColor]];
         [self setOpaque:NO];
@@ -202,6 +202,10 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth + kShado
     [rectPath setLineWidth:2*kBorderWidth];
     [rectPath stroke];
     [rectPath fill];
+}
+
+- (BOOL)allowsVibrancy {
+    return YES;
 }
 
 @end

--- a/Itsycal/ItsycalWindow.m
+++ b/Itsycal/ItsycalWindow.m
@@ -17,7 +17,7 @@ static const CGFloat kWindowTopMargin    = kCornerRadius + kBorderWidth + kArrow
 static const CGFloat kWindowSideMargin   = kBorderWidth  + kShadowWidth;
 static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth + kShadowWidth + kShadowWidth/2;
 
-@interface ItsycalWindowFrameView : NSView
+@interface ItsycalWindowFrameView : NSVisualEffectView
 @property (nonatomic, assign) CGFloat arrowMidX;
 @end
 
@@ -37,11 +37,13 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth + kShado
 {
     self = [super initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskNonactivatingPanel backing:NSBackingStoreBuffered defer:NO];
     if (self) {
+        [self setAppearance:[NSAppearance appearanceNamed:@"NSAppearanceNameVibrantLight"]];
+        //[NSAppearance appearanceNamed:@"NSAppearanceNameVibrantLight"]
         [self setBackgroundColor:[NSColor clearColor]];
         [self setOpaque:NO];
         [self setLevel:NSMainMenuWindowLevel];
         [self setMovableByWindowBackground:NO];
-        [self setHasShadow:NO];
+        [self setHasShadow:YES];
         [self setCollectionBehavior:NSWindowCollectionBehaviorMoveToActiveSpace];
         // Fade out when -[NSWindow orderOut:] is called.
         [self setAnimationBehavior:NSWindowAnimationBehaviorUtilityWindow];
@@ -187,16 +189,16 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth + kShado
     }
     
     // Shadow, stroke and fill.
-    static NSShadow *shadow = nil;
+    /*static NSShadow *shadow = nil;
     if (shadow == nil) {
         shadow = [NSShadow new];
         shadow.shadowColor = [NSColor colorWithWhite:0 alpha:0.4];
         shadow.shadowBlurRadius = kShadowWidth;
         shadow.shadowOffset = NSMakeSize(0, -kShadowWidth/2);
     }
-    [shadow set];
-    [[NSColor colorWithWhite:0.3 alpha:0.4] setStroke];
-    [[NSColor whiteColor] setFill];
+    [shadow set];*/
+    //[[NSColor colorWithWhite:0.3 alpha:0.4] setStroke];
+    [[NSColor controlBackgroundColor] setFill];
     [rectPath setLineWidth:2*kBorderWidth];
     [rectPath stroke];
     [rectPath fill];

--- a/Itsycal/ItsycalWindow.m
+++ b/Itsycal/ItsycalWindow.m
@@ -204,7 +204,7 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth + kShado
 }
 
 - (BOOL)allowsVibrancy {
-    return YES;
+    return [ItsyColors allowsVibrancy];
 }
 
 @end

--- a/Itsycal/MoButton.m
+++ b/Itsycal/MoButton.m
@@ -41,7 +41,7 @@
     // provide one of their own.
     _imgDarkened = [NSImage imageWithSize:_img.size flipped:NO drawingHandler:^BOOL(NSRect dstRect) {
         [_img drawInRect:dstRect];
-        [[NSColor colorWithRed:0.4 green:0.6 blue:1 alpha:1] set];
+        [[NSColor controlColor] set];
         NSRectFillUsingOperation(dstRect, NSCompositingOperationSourceAtop);
         return YES;
     }];

--- a/Itsycal/MoCalCell.m
+++ b/Itsycal/MoCalCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "MoCalCell.h"
+#import "ItsyColors.h"
 
 @implementation MoCalCell
 
@@ -14,9 +15,9 @@ static NSColor *kTodayCellColor=nil, *kHoveredCellColor=nil, *kSelectedCellColor
 
 + (void)initialize
 {
-    kTodayCellColor = [NSColor colorWithRed:0.4 green:0.6 blue:1 alpha:1];
-    kHoveredCellColor = [NSColor colorWithRed:0.2 green:0.2 blue:0.3 alpha:0.2];
-    kSelectedCellColor = [NSColor colorWithRed:0.3 green:0.3 blue:0.4 alpha:0.7];
+    kTodayCellColor = [ItsyColors getHighlightColor];
+    kHoveredCellColor = [ItsyColors getHoverColor];
+    kSelectedCellColor = [ItsyColors getBorderColor];
 }
 
 - (instancetype)init
@@ -25,7 +26,7 @@ static NSColor *kTodayCellColor=nil, *kHoveredCellColor=nil, *kSelectedCellColor
     if (self) {
         _textField = [[NSTextField alloc] initWithFrame:NSZeroRect];
         [_textField setFont:[NSFont systemFontOfSize:11 weight:NSFontWeightRegular]];
-        [_textField setTextColor:[NSColor textColor]];
+        [_textField setTextColor:[ItsyColors getPrimaryTextColor]];
         [_textField setBezeled:NO];
         [_textField setEditable:NO];
         [_textField setAlignment:NSTextAlignmentCenter];

--- a/Itsycal/MoCalCell.m
+++ b/Itsycal/MoCalCell.m
@@ -25,7 +25,7 @@ static NSColor *kTodayCellColor=nil, *kHoveredCellColor=nil, *kSelectedCellColor
     if (self) {
         _textField = [[NSTextField alloc] initWithFrame:NSZeroRect];
         [_textField setFont:[NSFont systemFontOfSize:11 weight:NSFontWeightRegular]];
-        [_textField setTextColor:[NSColor blackColor]];
+        [_textField setTextColor:[NSColor textColor]];
         [_textField setBezeled:NO];
         [_textField setEditable:NO];
         [_textField setAlignment:NSTextAlignmentCenter];

--- a/Itsycal/MoCalResizeHandle.m
+++ b/Itsycal/MoCalResizeHandle.m
@@ -4,6 +4,7 @@
 //
 
 #import "MoCalResizeHandle.h"
+#import "ItsyColors.h"
 
 @implementation MoCalResizeHandle
 {
@@ -17,8 +18,8 @@
         NSRect dotRect = NSMakeRect(0, 0, 4, 4);
         _dot = [NSImage imageWithSize:dotRect.size flipped:NO drawingHandler:^BOOL(NSRect dstRect) {
             NSGradient *g = [[NSGradient alloc] initWithColors:@[
-                [NSColor colorWithWhite:0 alpha:0.3],
-                [NSColor colorWithWhite:0 alpha:0.1]]];
+                [ItsyColors getPrimaryTextColor],
+                [ItsyColors getSecondaryTextColor]]];
             [g drawInBezierPath:[NSBezierPath bezierPathWithOvalInRect:dotRect] angle:-90];
             return YES;
         }];
@@ -33,7 +34,7 @@
 
 - (void)drawRect:(NSRect)dirtyRect
 {
-    [[NSColor colorWithWhite:0.86 alpha:1] set];
+    [[ItsyColors getPrimaryBackgroundColor] setFill];
     NSRectFill(NSMakeRect(0, 0, NSWidth(self.bounds), 6));
     CGFloat x = roundf((NSWidth(self.bounds) - _dot.size.width)/2.0);
     CGFloat y = roundf((6 - _dot.size.height)/2.0);

--- a/Itsycal/MoCalToolTipWC.m
+++ b/Itsycal/MoCalToolTipWC.m
@@ -7,6 +7,7 @@
 //
 
 #import "MoCalToolTipWC.h"
+#import "ItsyColors.h"
 
 static CGFloat kToolipWindowWidth = 200;
 
@@ -115,7 +116,7 @@ static CGFloat kToolipWindowWidth = 200;
 {
     self = [super initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:NO];
     if (self) {
-        self.backgroundColor = [NSColor controlBackgroundColor];
+        self.backgroundColor = [ItsyColors getPrimaryBackgroundColor];
         self.opaque = NO;
         self.level = NSPopUpMenuWindowLevel;
         self.movableByWindowBackground = NO;
@@ -142,8 +143,8 @@ static CGFloat kToolipWindowWidth = 200;
     // A yellow rounded rect with a light gray border.
     NSRect r = NSInsetRect(self.bounds, 1, 1);
     NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:r xRadius:4 yRadius:4];
-    //[[NSColor colorWithWhite:0 alpha:0.25] setStroke];
-    //[[NSColor colorWithRed:1 green:1 blue:0.95 alpha:1] setFill];
+    [[ItsyColors getBorderColor] setStroke];
+    [[ItsyColors getPrimaryBackgroundColor] setFill];
     [p setLineWidth: 2];
     [p stroke];[p fill];
 }

--- a/Itsycal/MoCalToolTipWC.m
+++ b/Itsycal/MoCalToolTipWC.m
@@ -115,7 +115,7 @@ static CGFloat kToolipWindowWidth = 200;
 {
     self = [super initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:NO];
     if (self) {
-        self.backgroundColor = [NSColor clearColor];
+        self.backgroundColor = [NSColor controlBackgroundColor];
         self.opaque = NO;
         self.level = NSPopUpMenuWindowLevel;
         self.movableByWindowBackground = NO;
@@ -142,8 +142,8 @@ static CGFloat kToolipWindowWidth = 200;
     // A yellow rounded rect with a light gray border.
     NSRect r = NSInsetRect(self.bounds, 1, 1);
     NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:r xRadius:4 yRadius:4];
-    [[NSColor colorWithWhite:0 alpha:0.25] setStroke];
-    [[NSColor colorWithRed:1 green:1 blue:0.95 alpha:1] setFill];
+    //[[NSColor colorWithWhite:0 alpha:0.25] setStroke];
+    //[[NSColor colorWithRed:1 green:1 blue:0.95 alpha:1] setFill];
     [p setLineWidth: 2];
     [p stroke];[p fill];
 }

--- a/Itsycal/MoCalendar.m
+++ b/Itsycal/MoCalendar.m
@@ -40,20 +40,18 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
 
 + (void)initialize
 {
-    kShadow = [NSShadow new];
-    kShadow.shadowColor = [NSColor colorWithWhite:0 alpha:0.2];
+    //kShadow = [NSShadow new];
+    //kShadow.shadowColor = [NSColor textColor];
     kShadow.shadowBlurRadius = 1;
     kShadow.shadowOffset = NSMakeSize(0, -1);
-    kBorderColor = [NSColor colorWithRed:0.86 green:0.86 blue:0.88 alpha:1];
-    kOutlineColor = [NSColor colorWithRed:0.7 green:0.7 blue:0.73 alpha:1];
-    kBorderColor = [NSColor colorWithWhite:0.86 alpha:1];
-    kOutlineColor = [NSColor colorWithWhite:0.76 alpha:1];
-    kLightTextColor = [NSColor colorWithWhite:0.15 alpha:0.6];
-    kDarkTextColor  = [NSColor colorWithWhite:0.15 alpha:1];
+    kBorderColor = [NSColor textBackgroundColor];
+    kOutlineColor = [NSColor textColor];
+    kLightTextColor = [NSColor textColor];
+    kDarkTextColor  = [NSColor textColor];
     kHighlightedDOWTextColor = [NSColor colorWithRed:0.75 green:0.2 blue:0.1 alpha:1];
-    kBackgroundColor = [NSColor whiteColor];
-    kWeeksBackgroundColor = [NSColor colorWithWhite:0.86 alpha:1];
-    kDatesBackgroundColor = [NSColor colorWithWhite:0.95 alpha:1];
+    kBackgroundColor = [NSColor controlBackgroundColor];
+    kWeeksBackgroundColor = [NSColor controlBackgroundColor];
+    kDatesBackgroundColor = [NSColor controlBackgroundColor];
 }
 
 - (instancetype)initWithFrame:(NSRect)frameRect
@@ -690,7 +688,7 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     [outlinePath setLineWidth:2];
     [outlinePath stroke];
     
-    [[NSColor whiteColor] set];
+    [[NSColor controlBackgroundColor] set];
     [NSGraphicsContext saveGraphicsState];
     [kShadow set];
     [outlinePath fill];
@@ -699,7 +697,7 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     if (self.highlightedDOWs) {
         NSRect weekendRect = [self convertRect:[_dateGrid cellsRect] fromView:_dateGrid];
         weekendRect.size.width = kMoCalCellWidth;
-        [[NSColor colorWithWhite:0.15 alpha:0.05] set];
+        [[NSColor textColor] set];
         NSInteger numColsToHighlight = 0;
         for (NSInteger col = 0; col <= 7; col++) {
             if (col < 7 && [self columnIsMemberOfHighlightedDOWs:col]) {
@@ -725,7 +723,7 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
         [t translateXBy:NSMinX(_dateGrid.frame) yBy:0];
         NSBezierPath *highlightPath = [_highlightPath copy];
         [highlightPath transformUsingAffineTransform:t];
-        NSColor *outlineColor = [_highlightColor blendedColorWithFraction:0.6 ofColor:[NSColor blackColor]];
+        NSColor *outlineColor = [_highlightColor blendedColorWithFraction:0.6 ofColor:[NSColor textBackgroundColor]];
         [[outlineColor colorWithAlphaComponent:0.3] setStroke];
         [[_highlightColor colorWithAlphaComponent:0.2] setFill];
         [highlightPath stroke];

--- a/Itsycal/MoCalendar.m
+++ b/Itsycal/MoCalendar.m
@@ -45,8 +45,8 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     kShadow.shadowBlurRadius = 1;
     kShadow.shadowOffset = NSMakeSize(0, -1);
     kBorderColor = [NSColor textBackgroundColor];
-    kOutlineColor = [NSColor textColor];
-    kLightTextColor = [NSColor textColor];
+    kOutlineColor = [NSColor controlBackgroundColor];
+    kLightTextColor = [NSColor secondaryLabelColor];
     kDarkTextColor  = [NSColor textColor];
     kHighlightedDOWTextColor = [NSColor colorWithRed:0.75 green:0.2 blue:0.1 alpha:1];
     kBackgroundColor = [NSColor controlBackgroundColor];
@@ -130,7 +130,7 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     [self addSubview:_dateGrid];
     [self addSubview:_weekGrid];
     [self addSubview:_dowGrid];
-    [self addSubview:_resizeHandle];
+    //[self addSubview:_resizeHandle];                              // Seems like I can't change the color of it? Is it really necessary?
 
     MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:self metrics:nil views:NSDictionaryOfVariableBindings(_monthLabel, _btnPrev, _btnToday, _btnNext, _dowGrid, _weekGrid, _dateGrid, _resizeHandle)];
     [vfl :@"H:|-8-[_monthLabel]-4-[_btnPrev]"];
@@ -140,11 +140,11 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     [vfl :@"V:|-2-[_btnPrev]"];
     [vfl :@"V:|[_monthLabel]-3-[_dowGrid]-(-2)-[_dateGrid]-1-|"];
     [vfl :@"V:[_weekGrid]-1-|"];
-    [vfl :@"V:[_resizeHandle(7)]|"];
+    //[vfl :@"V:[_resizeHandle(7)]|"];
 
     // _resizeHandle is aligned to leading/trailing of _dateGrid.
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:_dateGrid attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:_resizeHandle attribute:NSLayoutAttributeLeading multiplier:1 constant:0]];
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:_dateGrid attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:_resizeHandle attribute:NSLayoutAttributeTrailing multiplier:1 constant:0]];
+    //[self addConstraint:[NSLayoutConstraint constraintWithItem:_dateGrid attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:_resizeHandle attribute:NSLayoutAttributeLeading multiplier:1 constant:0]];
+    //[self addConstraint:[NSLayoutConstraint constraintWithItem:_dateGrid attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:_resizeHandle attribute:NSLayoutAttributeTrailing multiplier:1 constant:0]];
 
     _weeksConstraint = [NSLayoutConstraint constraintWithItem:_weekGrid attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1 constant:0];
     [self addConstraint:_weeksConstraint];

--- a/Itsycal/MoCalendar.m
+++ b/Itsycal/MoCalendar.m
@@ -698,7 +698,7 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     if (self.highlightedDOWs) {
         NSRect weekendRect = [self convertRect:[_dateGrid cellsRect] fromView:_dateGrid];
         weekendRect.size.width = kMoCalCellWidth;
-        [[ItsyColors getPrimaryTextColor] set];
+        [[[ItsyColors getPrimaryBackgroundColor] colorWithAlphaComponent:0.8]set];
         NSInteger numColsToHighlight = 0;
         for (NSInteger col = 0; col <= 7; col++) {
             if (col < 7 && [self columnIsMemberOfHighlightedDOWs:col]) {

--- a/Itsycal/MoCalendar.m
+++ b/Itsycal/MoCalendar.m
@@ -13,6 +13,7 @@
 #import "MoButton.h"
 #import "MoVFLHelper.h"
 #import "MoCalResizeHandle.h"
+#import "ItsyColors.h"
 
 NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
 
@@ -40,18 +41,18 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
 
 + (void)initialize
 {
-    //kShadow = [NSShadow new];
-    //kShadow.shadowColor = [NSColor textColor];
+    kShadow = [NSShadow new];
+    kShadow.shadowColor = [ItsyColors getShadowColor];
     kShadow.shadowBlurRadius = 1;
     kShadow.shadowOffset = NSMakeSize(0, -1);
-    kBorderColor = [NSColor textBackgroundColor];
-    kOutlineColor = [NSColor controlBackgroundColor];
-    kLightTextColor = [NSColor secondaryLabelColor];
-    kDarkTextColor  = [NSColor textColor];
-    kHighlightedDOWTextColor = [NSColor colorWithRed:0.75 green:0.2 blue:0.1 alpha:1];
-    kBackgroundColor = [NSColor controlBackgroundColor];
-    kWeeksBackgroundColor = [NSColor controlBackgroundColor];
-    kDatesBackgroundColor = [NSColor controlBackgroundColor];
+    kBorderColor = [ItsyColors getBorderColor];
+    kOutlineColor = [ItsyColors getBorderColor];
+    kLightTextColor = [ItsyColors getSecondaryTextColor];
+    kDarkTextColor  = [ItsyColors getPrimaryTextColor];
+    kHighlightedDOWTextColor = [ItsyColors getHighlightColor];
+    kBackgroundColor = [ItsyColors getPrimaryBackgroundColor];
+    kWeeksBackgroundColor = [ItsyColors getSecondaryBackgroundColor];
+    kDatesBackgroundColor = [ItsyColors getSecondaryBackgroundColor];
 }
 
 - (instancetype)initWithFrame:(NSRect)frameRect
@@ -124,14 +125,14 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     // The _resizeHandle is at the bottom of the calendar.
     _resizeHandle = [MoCalResizeHandle new];
     _resizeHandle.translatesAutoresizingMaskIntoConstraints = NO;
-    _resizeHandle.alphaValue = 0;
+    _resizeHandle.alphaValue = 1;
 
     [self addSubview:_monthLabel];
     [self addSubview:_dateGrid];
     [self addSubview:_weekGrid];
     [self addSubview:_dowGrid];
-    //[self addSubview:_resizeHandle];                              // Seems like I can't change the color of it? Is it really necessary?
-
+    [self addSubview:_resizeHandle];
+    
     MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:self metrics:nil views:NSDictionaryOfVariableBindings(_monthLabel, _btnPrev, _btnToday, _btnNext, _dowGrid, _weekGrid, _dateGrid, _resizeHandle)];
     [vfl :@"H:|-8-[_monthLabel]-4-[_btnPrev]"];
     [vfl :@"H:[_btnPrev]-2-[_btnToday]-2-[_btnNext]-6-|" :NSLayoutFormatAlignAllBottom];
@@ -140,11 +141,11 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     [vfl :@"V:|-2-[_btnPrev]"];
     [vfl :@"V:|[_monthLabel]-3-[_dowGrid]-(-2)-[_dateGrid]-1-|"];
     [vfl :@"V:[_weekGrid]-1-|"];
-    //[vfl :@"V:[_resizeHandle(7)]|"];
+    [vfl :@"V:[_resizeHandle(7)]|"];
 
     // _resizeHandle is aligned to leading/trailing of _dateGrid.
-    //[self addConstraint:[NSLayoutConstraint constraintWithItem:_dateGrid attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:_resizeHandle attribute:NSLayoutAttributeLeading multiplier:1 constant:0]];
-    //[self addConstraint:[NSLayoutConstraint constraintWithItem:_dateGrid attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:_resizeHandle attribute:NSLayoutAttributeTrailing multiplier:1 constant:0]];
+    [self addConstraint:[NSLayoutConstraint constraintWithItem:_dateGrid attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:_resizeHandle attribute:NSLayoutAttributeLeading multiplier:1 constant:0]];
+    [self addConstraint:[NSLayoutConstraint constraintWithItem:_dateGrid attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:_resizeHandle attribute:NSLayoutAttributeTrailing multiplier:1 constant:0]];
 
     _weeksConstraint = [NSLayoutConstraint constraintWithItem:_weekGrid attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1 constant:0];
     [self addConstraint:_weeksConstraint];
@@ -688,7 +689,7 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     [outlinePath setLineWidth:2];
     [outlinePath stroke];
     
-    [[NSColor controlBackgroundColor] set];
+    [[ItsyColors getPrimaryBackgroundColor] set];
     [NSGraphicsContext saveGraphicsState];
     [kShadow set];
     [outlinePath fill];
@@ -697,7 +698,7 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
     if (self.highlightedDOWs) {
         NSRect weekendRect = [self convertRect:[_dateGrid cellsRect] fromView:_dateGrid];
         weekendRect.size.width = kMoCalCellWidth;
-        [[NSColor textColor] set];
+        [[ItsyColors getPrimaryTextColor] set];
         NSInteger numColsToHighlight = 0;
         for (NSInteger col = 0; col <= 7; col++) {
             if (col < 7 && [self columnIsMemberOfHighlightedDOWs:col]) {
@@ -723,7 +724,7 @@ static NSColor *kBackgroundColor=nil, *kWeeksBackgroundColor=nil, *kDatesBackgro
         [t translateXBy:NSMinX(_dateGrid.frame) yBy:0];
         NSBezierPath *highlightPath = [_highlightPath copy];
         [highlightPath transformUsingAffineTransform:t];
-        NSColor *outlineColor = [_highlightColor blendedColorWithFraction:0.6 ofColor:[NSColor textBackgroundColor]];
+        NSColor *outlineColor = [_highlightColor blendedColorWithFraction:0.6 ofColor:[ItsyColors getBorderColor]];
         [[outlineColor colorWithAlphaComponent:0.3] setStroke];
         [[_highlightColor colorWithAlphaComponent:0.2] setFill];
         [highlightPath stroke];

--- a/Itsycal/MoTableView.m
+++ b/Itsycal/MoTableView.m
@@ -7,6 +7,7 @@
 //
 
 #import "MoTableView.h"
+#import "ItsyColors.h"
 
 @implementation MoTableView
 {
@@ -37,7 +38,7 @@
 {
     _enableHover = YES;
     _hoverRow    = -1;
-    _hoverColor  = [NSColor colorWithDeviceWhite:0.96 alpha:1];
+    _hoverColor  = [ItsyColors getSecondaryBackgroundColor];
     
     // Notify when enclosing scrollView scrolls.
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollViewScrolled:) name:NSViewBoundsDidChangeNotification object:[[self enclosingScrollView] contentView]];
@@ -57,7 +58,7 @@
     [super drawBackgroundInClipRect:clipRect];
     
     [self enumerateAvailableRowViewsUsingBlock:^(NSTableRowView *rowView, NSInteger row) {
-        rowView.backgroundColor = [NSColor controlBackgroundColor];
+        rowView.backgroundColor = [ItsyColors getPrimaryBackgroundColor];
         BOOL isGroupRow = NO;
         if ([self.delegate respondsToSelector:@selector(tableView:isGroupRow:)]) {
             isGroupRow = [self.delegate tableView:self isGroupRow:row];

--- a/Itsycal/MoTableView.m
+++ b/Itsycal/MoTableView.m
@@ -57,7 +57,7 @@
     [super drawBackgroundInClipRect:clipRect];
     
     [self enumerateAvailableRowViewsUsingBlock:^(NSTableRowView *rowView, NSInteger row) {
-        rowView.backgroundColor = [NSColor clearColor];
+        rowView.backgroundColor = [NSColor controlBackgroundColor];
         BOOL isGroupRow = NO;
         if ([self.delegate respondsToSelector:@selector(tableView:isGroupRow:)]) {
             isGroupRow = [self.delegate tableView:self isGroupRow:row];

--- a/Itsycal/MoTextField.m
+++ b/Itsycal/MoTextField.m
@@ -17,7 +17,7 @@
 {
     self = [super initWithFrame:frameRect];
     if (self) {
-        _linkColor = [NSColor colorWithRed:0.2 green:0.5 blue:0.9 alpha:1];
+        _linkColor = [NSColor textColor];
         _originalColor = self.textColor;
     }
     return self;
@@ -27,7 +27,7 @@
 {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        _linkColor = [NSColor colorWithRed:0.2 green:0.5 blue:0.9 alpha:1];
+        _linkColor = [NSColor textColor];
         _originalColor = self.textColor;
     }
     return self;

--- a/Itsycal/MoTextField.m
+++ b/Itsycal/MoTextField.m
@@ -7,6 +7,7 @@
 //
 
 #import "MoTextField.h"
+#import "ItsyColors.h"
 
 @implementation MoTextField
 {
@@ -17,7 +18,7 @@
 {
     self = [super initWithFrame:frameRect];
     if (self) {
-        _linkColor = [NSColor textColor];
+        _linkColor = [ItsyColors getPrimaryTextColor];
         _originalColor = self.textColor;
     }
     return self;
@@ -27,7 +28,7 @@
 {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        _linkColor = [NSColor textColor];
+        _linkColor = [ItsyColors getPrimaryTextColor];
         _originalColor = self.textColor;
     }
     return self;

--- a/Itsycal/MoView.m
+++ b/Itsycal/MoView.m
@@ -13,7 +13,7 @@
 void commonInitForMoView(MoView *moView)
 {
     moView.viewIsOpaque = YES;
-    moView.backgroundColor = [NSColor colorWithWhite:0.95 alpha:1];
+    moView.backgroundColor = [NSColor controlBackgroundColor];
     moView.translatesAutoresizingMaskIntoConstraints = NO;
 }
 

--- a/Itsycal/MoView.m
+++ b/Itsycal/MoView.m
@@ -7,13 +7,14 @@
 //
 
 #import "MoView.h"
+#import "ItsyColors.h"
 
 @implementation MoView
 
 void commonInitForMoView(MoView *moView)
 {
     moView.viewIsOpaque = YES;
-    moView.backgroundColor = [NSColor controlBackgroundColor];
+    moView.backgroundColor = [ItsyColors getPrimaryBackgroundColor];
     moView.translatesAutoresizingMaskIntoConstraints = NO;
 }
 

--- a/Itsycal/PrefsAppearanceVC.m
+++ b/Itsycal/PrefsAppearanceVC.m
@@ -19,6 +19,7 @@
     NSButton *_hideIcon;
     HighlightPicker *_highlight;
     NSButton *_showWeeks;
+    NSPopUpButton *_themeChooser;
 }
 
 #pragma mark -
@@ -29,6 +30,14 @@
     // View controller content view
     NSView *v = [NSView new];
 
+    // Convenience function for making labels.
+    MoTextField* (^label)(NSString*) = ^MoTextField* (NSString *stringValue) {
+        MoTextField *txt = [MoTextField labelWithString:stringValue];
+        txt.translatesAutoresizingMaskIntoConstraints = NO;
+        [v addSubview:txt];
+        return txt;
+    };
+    
     // Convenience function for making checkboxes.
     NSButton* (^chkbx)(NSString *) = ^NSButton* (NSString *title) {
         NSButton *chkbx = [NSButton checkboxWithTitle:title target:self action:nil];
@@ -43,6 +52,13 @@
     _showDayOfWeek = chkbx(NSLocalizedString(@"Show day of week in icon", @""));
     _showWeeks = chkbx(NSLocalizedString(@"Show calendar weeks", @""));
     _hideIcon = chkbx(NSLocalizedString(@"Hide icon", @""));
+    
+    // Theme chooser
+    MoTextField *themeLabel = label(@"Theme:");
+    _themeChooser = [NSPopUpButton new];
+    _themeChooser.translatesAutoresizingMaskIntoConstraints = NO;
+    [_themeChooser addItemsWithTitles:@[@"Default",@"Light",@"Dark"]];
+    [v addSubview:_themeChooser];
 
     // Datetime format text field
     _dateTimeFormat = [NSTextField textFieldWithString:nil];
@@ -70,8 +86,8 @@
     _highlight.action = @selector(didChangeHighlight:);
     [v addSubview:_highlight];
 
-    MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20} views:NSDictionaryOfVariableBindings(_useOutlineIcon, _showMonth, _showDayOfWeek, _showWeeks, _dateTimeFormat, helpButton, _hideIcon, _highlight)];
-    [vfl :@"V:|-m-[_useOutlineIcon]-[_showMonth]-[_showDayOfWeek]-m-[_dateTimeFormat]-[_hideIcon]-m-[_highlight]-m-[_showWeeks]-m-|"];
+    MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20} views:NSDictionaryOfVariableBindings(_useOutlineIcon, _showMonth, _showDayOfWeek, _showWeeks, _dateTimeFormat, helpButton, _hideIcon, _highlight, _themeChooser, themeLabel)];
+    [vfl :@"V:|-m-[_useOutlineIcon]-[_showMonth]-[_showDayOfWeek]-m-[_dateTimeFormat]-[_hideIcon]-m-[_highlight]-m-[_showWeeks]-m-[_themeChooser]|"];
     [vfl :@"H:|-m-[_useOutlineIcon]-(>=m)-|"];
     [vfl :@"H:|-m-[_showMonth]-(>=m)-|"];
     [vfl :@"H:|-m-[_showDayOfWeek]-(>=m)-|"];
@@ -79,6 +95,7 @@
     [vfl :@"H:|-m-[_hideIcon]-(>=m)-|"];
     [vfl :@"H:|-m-[_highlight]-(>=m)-|"];
     [vfl :@"H:|-m-[_showWeeks]-(>=m)-|"];
+    [vfl :@"H:|-m-[themeLabel]-[_themeChooser]-(>=m)-|" :NSLayoutFormatAlignAllFirstBaseline];
 
     self.view = v;
 }
@@ -108,6 +125,9 @@
     [_highlight bind:@"weekStartDOW" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kWeekStartDOW] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     [_highlight bind:@"selectedDOWs" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kHighlightedDOWs] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
 
+    [_themeChooser bind:@"selectedIndex" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kThemeName] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
+
+    
     [self updateHideIconState];
 
     // We don't want _dateTimeFormat to be first responder.

--- a/Itsycal/TooltipViewController.m
+++ b/Itsycal/TooltipViewController.m
@@ -8,12 +8,13 @@
 
 #import "TooltipViewController.h"
 #import "EventCenter.h"
+#import "ItsyColors.h"
 
 @implementation TooltipViewController
 
 - (void)toolTipForDate:(MoDate)date
 {
-    self.backgroundColor = [NSColor colorWithRed:1 green:1 blue:0.95 alpha:1];
+    self.backgroundColor = [ItsyColors getSecondaryBackgroundColor];
     self.tv.enclosingScrollView.hasVerticalScroller = NO; // in case user has System Prefs set to always show scroller
     self.events = [self.ec eventsForDate:date];
     [self reloadData];

--- a/Itsycal/ViewController.h
+++ b/Itsycal/ViewController.h
@@ -10,6 +10,7 @@
 #import "MoCalendar.h"
 #import "EventCenter.h"
 #import "AgendaViewController.h"
+#import "ItsyColors.h"
 
 @interface ViewController : NSViewController <NSWindowDelegate, AgendaDelegate, MoCalendarDelegate, EventCenterDelegate>
 

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -432,10 +432,10 @@
 
             // Draw outlined icon image.
 
-            [[NSColor controlTextColor] set];
+            [[ItsyColors getBorderColor] set];
             [[NSBezierPath bezierPathWithRoundedRect:NSInsetRect(rect, 3.5, 0.5) xRadius:2 yRadius:2] stroke];
 
-            [[NSColor controlTextColor] set];
+            [[ItsyColors getBorderColor] set];
             NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:NSInsetRect(rect, 4, 1) xRadius:1 yRadius:1];
             [p setLineWidth:2];
             [p stroke];
@@ -446,7 +446,7 @@
             // Draw text.
             NSMutableParagraphStyle *pstyle = [NSMutableParagraphStyle new];
             pstyle.alignment = NSTextAlignmentCenter;
-            [text drawInRect:NSOffsetRect(rect, 0, -1) withAttributes:@{NSFontAttributeName: [NSFont systemFontOfSize:11.5 weight:NSFontWeightSemibold], NSParagraphStyleAttributeName: pstyle, NSForegroundColorAttributeName: [NSColor controlBackgroundColor]}];
+            [text drawInRect:NSOffsetRect(rect, 0, -1) withAttributes:@{NSFontAttributeName: [NSFont systemFontOfSize:11.5 weight:NSFontWeightSemibold], NSParagraphStyleAttributeName: pstyle, NSForegroundColorAttributeName: [ItsyColors getPrimaryBackgroundColor]}];
         }
         else {
 
@@ -474,13 +474,13 @@
             [NSGraphicsContext setCurrentContext:maskGraphicsContext];
 
             // Draw a white rounded rect background into the mask context
-            [[NSColor controlBackgroundColor] setFill];
+            [[ItsyColors getBorderColor] setFill];
             [[NSBezierPath bezierPathWithRoundedRect:NSInsetRect(deviceRect, outsideMargin, 0) xRadius:radius yRadius:radius] fill];
 
             // Draw text.
             NSMutableParagraphStyle *pstyle = [NSMutableParagraphStyle new];
             pstyle.alignment = NSTextAlignmentCenter;
-            [text drawInRect:NSOffsetRect(deviceRect, 0, -1) withAttributes:@{NSFontAttributeName: [NSFont systemFontOfSize:fontSize weight:NSFontWeightBold], NSForegroundColorAttributeName: [NSColor controlBackgroundColor], NSParagraphStyleAttributeName: pstyle}];
+            [text drawInRect:NSOffsetRect(deviceRect, 0, -1) withAttributes:@{NSFontAttributeName: [NSFont systemFontOfSize:fontSize weight:NSFontWeightBold], NSForegroundColorAttributeName: [ItsyColors getPrimaryBackgroundColor], NSParagraphStyleAttributeName: pstyle}];
 
             // Switch back to the image's context.
             [NSGraphicsContext restoreGraphicsState];
@@ -490,7 +490,7 @@
 
             // Fill the image, clipped by the mask.
             CGContextClipToMask(ctx, rect, alphaMask);
-            [[NSColor controlTextColor] set];
+            [[ItsyColors getBorderColor] set];
             NSRectFill(rect);
 
             CGImageRelease(alphaMask);

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -54,7 +54,6 @@
 {
     // View controller content view
     NSView *v = [NSView new];
-    v.translatesAutoresizingMaskIntoConstraints = NO;
     
     // MoCalendar
     _moCal = [MoCalendar new];
@@ -433,10 +432,10 @@
 
             // Draw outlined icon image.
 
-            [[NSColor colorWithWhite:0 alpha:0.9] set];
+            [[NSColor controlTextColor] set];
             [[NSBezierPath bezierPathWithRoundedRect:NSInsetRect(rect, 3.5, 0.5) xRadius:2 yRadius:2] stroke];
 
-            [[NSColor colorWithWhite:0 alpha:0.15] set];
+            [[NSColor controlTextColor] set];
             NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:NSInsetRect(rect, 4, 1) xRadius:1 yRadius:1];
             [p setLineWidth:2];
             [p stroke];
@@ -447,7 +446,7 @@
             // Draw text.
             NSMutableParagraphStyle *pstyle = [NSMutableParagraphStyle new];
             pstyle.alignment = NSTextAlignmentCenter;
-            [text drawInRect:NSOffsetRect(rect, 0, -1) withAttributes:@{NSFontAttributeName: [NSFont systemFontOfSize:11.5 weight:NSFontWeightSemibold], NSParagraphStyleAttributeName: pstyle, NSForegroundColorAttributeName: [NSColor blackColor]}];
+            [text drawInRect:NSOffsetRect(rect, 0, -1) withAttributes:@{NSFontAttributeName: [NSFont systemFontOfSize:11.5 weight:NSFontWeightSemibold], NSParagraphStyleAttributeName: pstyle, NSForegroundColorAttributeName: [NSColor controlBackgroundColor]}];
         }
         else {
 
@@ -475,13 +474,13 @@
             [NSGraphicsContext setCurrentContext:maskGraphicsContext];
 
             // Draw a white rounded rect background into the mask context
-            [[NSColor whiteColor] setFill];
+            [[NSColor controlBackgroundColor] setFill];
             [[NSBezierPath bezierPathWithRoundedRect:NSInsetRect(deviceRect, outsideMargin, 0) xRadius:radius yRadius:radius] fill];
 
             // Draw text.
             NSMutableParagraphStyle *pstyle = [NSMutableParagraphStyle new];
             pstyle.alignment = NSTextAlignmentCenter;
-            [text drawInRect:NSOffsetRect(deviceRect, 0, -1) withAttributes:@{NSFontAttributeName: [NSFont systemFontOfSize:fontSize weight:NSFontWeightBold], NSForegroundColorAttributeName: [NSColor blackColor], NSParagraphStyleAttributeName: pstyle}];
+            [text drawInRect:NSOffsetRect(deviceRect, 0, -1) withAttributes:@{NSFontAttributeName: [NSFont systemFontOfSize:fontSize weight:NSFontWeightBold], NSForegroundColorAttributeName: [NSColor controlBackgroundColor], NSParagraphStyleAttributeName: pstyle}];
 
             // Switch back to the image's context.
             [NSGraphicsContext restoreGraphicsState];
@@ -491,7 +490,7 @@
 
             // Fill the image, clipped by the mask.
             CGContextClipToMask(ctx, rect, alphaMask);
-            [[NSColor blackColor] set];
+            [[NSColor controlTextColor] set];
             NSRectFill(rect);
 
             CGImageRelease(alphaMask);


### PR DESCRIPTION
See [#21](https://github.com/sfsam/Itsycal/issues/21)
![themes](https://user-images.githubusercontent.com/1122217/27036971-ddb9b6ac-4f86-11e7-9598-affd1c739c7a.jpg)
A lot of changes here I'll try to explain in brief:

- Added the class ItsyColors. This will be the "hub" for defining new color schemes or behaviour. Every (I hope so 🤕) NSColor hard coded is now replaced with a get from this class.
- Added the preference select to change the actual theme.
- Copied the default theme from your actual color scheme. I know it's not exactly the same but I think it's very convient to have a few colors easily changeable from a single position.

Missing:

- When you change the theme in the preference you have to quit and reopen the app.
- Seems like I can't change the color of the resize handler consistently.
- Also the colors of the highlight days it's odd.
- Proper internalization (if needed) for the new preference panel.