### PR TITLE
Add support to japanese calendar

### DIFF
--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -122,8 +122,15 @@
     _iconDateFormatter = [NSDateFormatter new];
     _inactiveTime = 0;
 
-    // Calendar is 'autoupdating' so it handles timezone changes properly.
-    _nsCal = [NSCalendar autoupdatingCurrentCalendar];
+    if ([[NSLocale currentLocale].localeIdentifier rangeOfString:@"JP"].location != NSNotFound) {
+        // without this, NSCalendarUnitYear will got year of the reign of the current Japanese Emperor
+        _nsCal = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    } else {
+        // Calendar is 'autoupdating' so it handles timezone changes properly.
+        _nsCal = [NSCalendar autoupdatingCurrentCalendar];
+    }
+    
+    
     _agendaVC.nsCal = _nsCal;
     
     MoDate today = [self todayDate];


### PR DESCRIPTION
Itsycal does not work properly for people using japanese calendar (local: en_JP or ja_JP)
the calendar looks like 'September 26, 30 Heisei' or 'September 26, 30 平成' 
So the NSCalendarUnitYear got 30 instead of 2018, 

I like Itsycal,  so I fix it for myself.

I'm not good at object-c
feel free to close the PR and fix it the right way