### PR TITLE
Use system accent color if it's available.

### DIFF
--- a/Itsycal/Themer.m
+++ b/Itsycal/Themer.m
@@ -169,6 +169,9 @@ typedef enum : NSInteger {
 
 - (NSColor *)todayCellColor
 {
+    if (@available(macOS 10.14, *)) {
+        return [NSColor controlAccentColor];
+    }
     return self.theme != ThemeLight
     ? [NSColor colorWithRed:0.36 green:0.54 blue:0.9 alpha:1]
     : [NSColor colorWithRed:0.4 green:0.6 blue:1 alpha:1];


### PR DESCRIPTION
hey @sfsam - not sure if you want to handle this design detail in this way or not, but i definitely think it would be better to support system accent color :)

(feel free to close the pr if you think it's just a personal preference)

anyway - thanks for building this awesome app, big fan.