### PR TITLE
Add new icon style "Only Text"

### DIFF
--- a/Itsycal.xcodeproj/project.pbxproj
+++ b/Itsycal.xcodeproj/project.pbxproj
@@ -311,7 +311,7 @@
 		9242A5541A82A136005AA4B3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = mowglii.com;
 				TargetAttributes = {
 					9242A55B1A82A136005AA4B3 = {
@@ -489,7 +489,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -543,7 +543,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -567,9 +567,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Itsycal/Itsycal.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Development";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = HFT3T55WND;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -588,10 +588,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Itsycal/Itsycal.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Development";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = HFT3T55WND;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Itsycal.xcodeproj/project.pbxproj
+++ b/Itsycal.xcodeproj/project.pbxproj
@@ -311,7 +311,7 @@
 		9242A5541A82A136005AA4B3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1030;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = mowglii.com;
 				TargetAttributes = {
 					9242A55B1A82A136005AA4B3 = {
@@ -489,7 +489,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -543,7 +543,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -567,9 +567,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Itsycal/Itsycal.entitlements;
-				CODE_SIGN_IDENTITY = "Mac Development";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HFT3T55WND;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -588,10 +588,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Itsycal/Itsycal.entitlements;
-				CODE_SIGN_IDENTITY = "Mac Development";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HFT3T55WND;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Itsycal/Itsycal.h
+++ b/Itsycal/Itsycal.h
@@ -16,7 +16,7 @@ extern NSString * const kShowWeeks;
 extern NSString * const kWeekStartDOW;
 extern NSString * const kHighlightedDOWs;
 extern NSString * const kKeyboardShortcut;
-extern NSString * const kUseOutlineIcon;
+extern NSString * const kIconPreference;
 extern NSString * const kShowMonthInIcon;
 extern NSString * const kShowDayOfWeekInIcon;
 extern NSString * const kAllowOutsideApplicationsFolder;

--- a/Itsycal/Itsycal.m
+++ b/Itsycal/Itsycal.m
@@ -15,7 +15,6 @@ NSString * const kShowWeeks = @"ShowWeeks";
 NSString * const kWeekStartDOW = @"WeekStartDOW";
 NSString * const kHighlightedDOWs = @"HighlightedDOWs";
 NSString * const kKeyboardShortcut = @"KeyboardShortcut";
-NSString * const kUseOutlineIcon = @"UseOutlineIcon";
 NSString * const kShowMonthInIcon = @"ShowMonthInIcon";
 NSString * const kShowDayOfWeekInIcon = @"ShowDayOfWeekInIcon";
 NSString * const kAllowOutsideApplicationsFolder = @"AllowOutsideApplicationsFolder";
@@ -23,3 +22,7 @@ NSString * const kClockFormat = @"ClockFormat";
 NSString * const kHideIcon = @"HideIcon";
 NSString * const kShowLocation = @"ShowLocation";
 NSString * const kShowEventDots = @"kShowEventDots";
+
+// NSUserDefaults key
+NSString * const kIconPreference = @"IconPreference";
+

--- a/Itsycal/PrefsAppearanceVC.m
+++ b/Itsycal/PrefsAppearanceVC.m
@@ -13,7 +13,6 @@
 
 @implementation PrefsAppearanceVC
 {
-    NSButton *_useOutlineIcon;
     NSButton *_showMonth;
     NSButton *_showDayOfWeek;
     NSTextField *_dateTimeFormat;
@@ -22,7 +21,8 @@
     NSButton *_showEventDots;
     NSButton *_showWeeks;
     NSButton *_showLocation;
-    NSPopUpButton *_themePopup;
+	NSPopUpButton *_themePopup;
+	NSPopUpButton *_iconPopup;
     NSButton *_bigger;
 }
 
@@ -42,8 +42,28 @@
         return chkbx;
     };
 
+	///////////////////
+	// Icon label
+
+	NSTextField *iconLabel = [NSTextField labelWithString:NSLocalizedString(@"Icon Style:", @"")];
+	iconLabel.translatesAutoresizingMaskIntoConstraints = NO;
+	[v addSubview:iconLabel];
+	
+	// Icon Preference popup (solid / outline / text)
+	_iconPopup = [NSPopUpButton new];
+	_iconPopup.translatesAutoresizingMaskIntoConstraints = NO;
+	
+	[_iconPopup addItemWithTitle:NSLocalizedString(@"Solid", @"Solid Icon Style")];
+	[_iconPopup addItemWithTitle:NSLocalizedString(@"Outline", @"Outline Icon Style")];
+	[_iconPopup addItemWithTitle:NSLocalizedString(@"Text", @"Plain Text Icon Style")];
+	// The tags will be used to bind the selected theme
+	// preference to NSUserDefaults.
+	[_iconPopup itemAtIndex:0].tag = 0; // Inverse
+	[_iconPopup itemAtIndex:1].tag = 1; // Outline
+	[_iconPopup itemAtIndex:2].tag = 2; // Text Only
+	[v addSubview:_iconPopup];
+
     // Checkboxes
-    _useOutlineIcon = chkbx(NSLocalizedString(@"Use outline icon", @""));
     _showMonth = chkbx(NSLocalizedString(@"Show month in icon", @""));
     _showDayOfWeek = chkbx(NSLocalizedString(@"Show day of week in icon", @""));
     _showEventDots = chkbx(NSLocalizedString(@"Show event dots", @""));
@@ -105,10 +125,11 @@
         [_themePopup itemAtIndex:1].tag = 2; // Dark
     }
     [v addSubview:_themePopup];
-    
-    MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20} views:NSDictionaryOfVariableBindings(_bigger, _useOutlineIcon, _showMonth, _showDayOfWeek, _showEventDots, _showWeeks, _showLocation, _dateTimeFormat, helpButton, _hideIcon, _highlight, themeLabel, _themePopup)];
-    [vfl :@"V:|-m-[_useOutlineIcon]-[_showMonth]-[_showDayOfWeek]-m-[_dateTimeFormat]-[_hideIcon]-m-[_themePopup]-m-[_highlight]-m-[_showEventDots]-[_showLocation]-[_showWeeks]-m-[_bigger]-m-|"];
-    [vfl :@"H:|-m-[_useOutlineIcon]-(>=m)-|"];
+	
+	
+    MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20} views:NSDictionaryOfVariableBindings(_bigger, iconLabel, _iconPopup, _showMonth, _showDayOfWeek, _showEventDots, _showWeeks, _showLocation, _dateTimeFormat, helpButton, _hideIcon, _highlight, themeLabel, _themePopup)];
+	[vfl :@"H:|-m-[iconLabel]-[_iconPopup]-(>=m)-|" :NSLayoutFormatAlignAllFirstBaseline];
+    [vfl :@"V:|-m-[_iconPopup]-m-[_showMonth]-[_showDayOfWeek]-m-[_dateTimeFormat]-[_hideIcon]-m-[_themePopup]-m-[_highlight]-m-[_showEventDots]-[_showLocation]-[_showWeeks]-m-[_bigger]-m-|"];
     [vfl :@"H:|-m-[_showMonth]-(>=m)-|"];
     [vfl :@"H:|-m-[_showDayOfWeek]-(>=m)-|"];
     [vfl :@"H:|-m-[_dateTimeFormat]-[helpButton]-m-|" :NSLayoutFormatAlignAllCenterY];
@@ -128,13 +149,15 @@
     [super viewWillAppear];
 
     // Bindings for icon preferences
-    [_useOutlineIcon bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kUseOutlineIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
+	[_iconPopup bind:@"selectedTag" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kIconPreference] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
+
+    // [_useOutlineIcon bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kUseOutlineIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     [_showMonth bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowMonthInIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     [_showDayOfWeek bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowDayOfWeekInIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     [_hideIcon bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kHideIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
 
     // Bind icon prefs enabled state to hide icon's value
-    [_useOutlineIcon bind:@"enabled" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kHideIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES), NSValueTransformerNameBindingOption: NSNegateBooleanTransformerName}];
+    // [_useOutlineIcon bind:@"enabled" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kHideIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES), NSValueTransformerNameBindingOption: NSNegateBooleanTransformerName}];
     [_showMonth bind:@"enabled" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kHideIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES), NSValueTransformerNameBindingOption: NSNegateBooleanTransformerName}];
     [_showDayOfWeek bind:@"enabled" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kHideIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES), NSValueTransformerNameBindingOption: NSNegateBooleanTransformerName}];
 
@@ -157,7 +180,7 @@
     // Bindings for theme
     [_themePopup bind:@"selectedTag" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kThemePreference] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     
-    // Bindings for size
+	// Bindings for size
     [_bigger bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kSizePreference] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     
     [self updateHideIconState];

--- a/Itsycal/PrefsAppearanceVC.m
+++ b/Itsycal/PrefsAppearanceVC.m
@@ -21,8 +21,8 @@
     NSButton *_showEventDots;
     NSButton *_showWeeks;
     NSButton *_showLocation;
-	NSPopUpButton *_themePopup;
-	NSPopUpButton *_iconPopup;
+    NSPopUpButton *_themePopup;
+    NSPopUpButton *_iconPopup;
     NSButton *_bigger;
 }
 
@@ -41,10 +41,10 @@
         [v addSubview:chkbx];
         return chkbx;
     };
-    
+
     ///////////////////
     // Icon label
-    
+
     NSTextField *iconLabel = [NSTextField labelWithString:NSLocalizedString(@"Icon Style:", @"")];
     iconLabel.translatesAutoresizingMaskIntoConstraints = NO;
     [v addSubview:iconLabel];

--- a/Itsycal/PrefsAppearanceVC.m
+++ b/Itsycal/PrefsAppearanceVC.m
@@ -41,27 +41,27 @@
         [v addSubview:chkbx];
         return chkbx;
     };
-
-	///////////////////
-	// Icon label
-
-	NSTextField *iconLabel = [NSTextField labelWithString:NSLocalizedString(@"Icon Style:", @"")];
-	iconLabel.translatesAutoresizingMaskIntoConstraints = NO;
-	[v addSubview:iconLabel];
-	
-	// Icon Preference popup (solid / outline / text)
-	_iconPopup = [NSPopUpButton new];
-	_iconPopup.translatesAutoresizingMaskIntoConstraints = NO;
-	
-	[_iconPopup addItemWithTitle:NSLocalizedString(@"Solid", @"Solid Icon Style")];
-	[_iconPopup addItemWithTitle:NSLocalizedString(@"Outline", @"Outline Icon Style")];
-	[_iconPopup addItemWithTitle:NSLocalizedString(@"Text", @"Plain Text Icon Style")];
-	// The tags will be used to bind the selected theme
-	// preference to NSUserDefaults.
-	[_iconPopup itemAtIndex:0].tag = 0; // Inverse
-	[_iconPopup itemAtIndex:1].tag = 1; // Outline
-	[_iconPopup itemAtIndex:2].tag = 2; // Text Only
-	[v addSubview:_iconPopup];
+    
+    ///////////////////
+    // Icon label
+    
+    NSTextField *iconLabel = [NSTextField labelWithString:NSLocalizedString(@"Icon Style:", @"")];
+    iconLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [v addSubview:iconLabel];
+    
+    // Icon Preference popup (solid / outline / text)
+    _iconPopup = [NSPopUpButton new];
+    _iconPopup.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    [_iconPopup addItemWithTitle:NSLocalizedString(@"Solid", @"Solid Icon Style")];
+    [_iconPopup addItemWithTitle:NSLocalizedString(@"Outline", @"Outline Icon Style")];
+    [_iconPopup addItemWithTitle:NSLocalizedString(@"Text", @"Plain Text Icon Style")];
+    // The tags will be used to bind the selected theme
+    // preference to NSUserDefaults.
+    [_iconPopup itemAtIndex:0].tag = 0; // Inverse
+    [_iconPopup itemAtIndex:1].tag = 1; // Outline
+    [_iconPopup itemAtIndex:2].tag = 2; // Text Only
+    [v addSubview:_iconPopup];
 
     // Checkboxes
     _showMonth = chkbx(NSLocalizedString(@"Show month in icon", @""));
@@ -125,10 +125,10 @@
         [_themePopup itemAtIndex:1].tag = 2; // Dark
     }
     [v addSubview:_themePopup];
-	
-	
+
+
     MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20} views:NSDictionaryOfVariableBindings(_bigger, iconLabel, _iconPopup, _showMonth, _showDayOfWeek, _showEventDots, _showWeeks, _showLocation, _dateTimeFormat, helpButton, _hideIcon, _highlight, themeLabel, _themePopup)];
-	[vfl :@"H:|-m-[iconLabel]-[_iconPopup]-(>=m)-|" :NSLayoutFormatAlignAllFirstBaseline];
+    [vfl :@"H:|-m-[iconLabel]-[_iconPopup]-(>=m)-|" :NSLayoutFormatAlignAllFirstBaseline];
     [vfl :@"V:|-m-[_iconPopup]-m-[_showMonth]-[_showDayOfWeek]-m-[_dateTimeFormat]-[_hideIcon]-m-[_themePopup]-m-[_highlight]-m-[_showEventDots]-[_showLocation]-[_showWeeks]-m-[_bigger]-m-|"];
     [vfl :@"H:|-m-[_showMonth]-(>=m)-|"];
     [vfl :@"H:|-m-[_showDayOfWeek]-(>=m)-|"];
@@ -149,7 +149,7 @@
     [super viewWillAppear];
 
     // Bindings for icon preferences
-	[_iconPopup bind:@"selectedTag" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kIconPreference] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
+    [_iconPopup bind:@"selectedTag" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kIconPreference] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
 
     // [_useOutlineIcon bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kUseOutlineIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     [_showMonth bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowMonthInIcon] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -455,14 +455,14 @@
 {
     if (text == nil) text = @"!";
 
-	NSInteger iconPreference = [[NSUserDefaults standardUserDefaults] integerForKey:kIconPreference];
-	
-	// Does user want outline icon, solid icon or just text?
-	BOOL useOutlineIcon = iconPreference != 0;
-	BOOL drawOutline = iconPreference == 1;
+    NSInteger iconPreference = [[NSUserDefaults standardUserDefaults] integerForKey:kIconPreference];
+
+    // Does user want outline icon, solid icon or just text?
+    BOOL useOutlineIcon = iconPreference != 0;
+    BOOL drawOutline = iconPreference == 1;
 
     // Return cached icon if one is available.
-	NSString *iconName = [text stringByAppendingString:iconPreference == 0 ? @" inverse" : iconPreference==1 ? @" outline" : @" text"];
+    NSString *iconName = [text stringByAppendingString:iconPreference == 0 ? @" inverse" : iconPreference==1 ? @" outline" : @" text"];
     NSImage *iconImage = [NSImage imageNamed:iconName];
 
     if (iconImage != nil) {
@@ -476,7 +476,7 @@
     CGRect textRect = [[[NSAttributedString alloc] initWithString:text attributes:@{NSFontAttributeName: font}] boundingRectWithSize:CGSizeMake(999, 999) options:0 context:nil];
 
     // Icon width is at least 23 pts with 3 pt outside margins, 4 pt inside margins.
-	CGFloat width = MAX(3 + 4 + ceilf(NSWidth(textRect)) + 4 + 3 - (iconPreference==2?6:0), 23);
+    CGFloat width = MAX(3 + 4 + ceilf(NSWidth(textRect)) + 4 + 3 - (iconPreference==2?6:0), 23);
     CGFloat height = 16 + (useOutlineIcon && !drawOutline ? 2 : 0);
     
     iconImage = [NSImage imageWithSize:NSMakeSize(width, height) flipped:NO drawingHandler:^BOOL (NSRect rect) {

--- a/README.txt
+++ b/README.txt
@@ -13,3 +13,12 @@ and delete (but not edit) events.
 For more info, see: http://www.mowglii.com/itsycal
 
 MIT Licensed - see License file
+
+= = = = = = = = =
+
+nebular fork:
+
+- added new icon style "TEXT" that just draws the text without
+  outline or solid background, just like OSX if using Show Date
+  on Date/Time preferences.
+


### PR DESCRIPTION
This new icon style just draws the text without any outline or solid background, just like OSX does in its default clock if you show the date.

I changed the preference window so instead of a checkbox "Show Icon Outline" it now shows a popup window with three options: Solid, Outline, Text

![image](https://user-images.githubusercontent.com/1264021/65915513-e0c32200-e3d3-11e9-9fc0-975362a0120e.png)


![image](https://user-images.githubusercontent.com/1264021/65897909-a1cfa500-e3b0-11e9-8a35-73e348955bc0.png)

