### PR TITLE
if teams event remove < and > in notes before create htmldata

### DIFF
--- a/Itsycal/AgendaViewController.m
+++ b/Itsycal/AgendaViewController.m
@@ -919,6 +919,11 @@ static NSString *kEventCellIdentifier = @"EventCell";
             [_textGrid rowAtIndex:4].hidden = YES;
         }
         else {
+            if ([trimmedNotes containsString:@"https://teams.microsoft.com"])
+            {
+                trimmedNotes = [trimmedNotes stringByReplacingOccurrencesOfString:@"<" withString:@" "];
+                trimmedNotes = [trimmedNotes stringByReplacingOccurrencesOfString:@">" withString:@" "];
+            }
             [self populateTextView:_note withString:trimmedNotes heightConstraint:_noteHeight];
         }
     }
@@ -949,6 +954,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     string = [string stringByReplacingOccurrencesOfString:@"\n" withString:@"<br>"];
     NSData *htmlData = [string dataUsingEncoding:NSUnicodeStringEncoding];
     NSMutableAttributedString *attrString = [[NSMutableAttributedString alloc] initWithHTML:htmlData documentAttributes:nil];
+    
     
     [attrString addAttribute:NSFontAttributeName value:[NSFont systemFontOfSize:[[Sizer shared] fontSize]] range:NSMakeRange(0, attrString.length)];
     [attrString addAttribute:NSForegroundColorAttributeName value:Theme.agendaEventTextColor range:NSMakeRange(0, attrString.length)];


### PR DESCRIPTION
Hi,
  this is a fast and dirty hack to restore urls in Microsoft Teams events. 
This request could close issues #136 even if I think that it is necessary an ad hoc 
parser for Microsoft Teams events