### PR TITLE
Fix trackpad click on edges not opening calendar

### DIFF
--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -416,6 +416,7 @@
     _statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
     _statusItem.button.target = self;
     _statusItem.button.action = @selector(statusItemClicked:);
+    [_statusItem.button sendActionOn:NSEventMaskLeftMouseDown];
     [(NSButtonCell *)_statusItem.button.cell setHighlightsBy:NSNoCellMask];
 
     // Remember item position in menubar. (@pskowronek (Github))


### PR DESCRIPTION
Fixes #171 

When you click (pressing down the trackpad) on the edges of the menu item, it flashes but doesn't open the calendar.