### PR TITLE
added integration for Chime meetings

### DIFF
--- a/Itsycal/EventCenter.m
+++ b/Itsycal/EventCenter.m
@@ -385,6 +385,15 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
                     if (appLink) info.zoomURL = appLink;
                 }
             }
+            else if ([link containsString:@"chime.aws/"]) {
+                info.zoomURL = result.URL;
+                // Test if user has the Chime app, and if so, create a Chime app link.
+                if ([NSWorkspace.sharedWorkspace URLForApplicationToOpenURL:[NSURL URLWithString:@"chime://"]]) {
+                    link = [link stringByReplacingOccurrencesOfString:@"https://chime.aws/" withString:@"chime://meeting?pin="];
+                    NSURL *appLink = [NSURL URLWithString:link];
+                    if (appLink) info.zoomURL = appLink;
+                }
+            }
             else if (   [link containsString:@"zoommtg://"]
                      || [link containsString:@"meet.google.com/"]
                      || [link containsString:@"hangouts.google.com/"]


### PR DESCRIPTION
The set of changes open the chime app directly if present on the system, by detecting chime links within the meeting invite.

Chime is the meeting tool by Amazon and is extensively used within Amazon. This will help anyone using this tool to have a link for the meetings. 