### PR TITLE
Handle conversion of zoom http links for app

### DIFF
--- a/Itsycal/EventCenter.m
+++ b/Itsycal/EventCenter.m
@@ -377,6 +377,7 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
                 // Test if user has the Zoom app and, if so, create a Zoom app link.
                 if ([NSWorkspace.sharedWorkspace URLForApplicationToOpenURL:[NSURL URLWithString:@"zoommtg://"]]) {
                     link = [link stringByReplacingOccurrencesOfString:@"https://" withString:@"zoommtg://"];
+                    link = [link stringByReplacingOccurrencesOfString:@"http://" withString:@"zoommtg://"];
                     link = [link stringByReplacingOccurrencesOfString:@"?" withString:@"&"];
                     link = [link stringByReplacingOccurrencesOfString:@"/j/" withString:@"/join?confno="];
                     link = [link stringByReplacingOccurrencesOfString:@"/s/" withString:@"/join?confno="];


### PR DESCRIPTION
For whatever reason my calendar has ended up with http rather than https
links. This handles conversion accordingly.