### PR TITLE
Add support for zoomgov

### DIFF
--- a/Itsycal/EventCenter.m
+++ b/Itsycal/EventCenter.m
@@ -372,7 +372,10 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
             NSString *link = result.URL.absoluteString;
             if (   [link containsString:@"zoom.us/j/"]
                 || [link containsString:@"zoom.us/s/"]
-                || [link containsString:@"zoom.us/w/"]) {
+                || [link containsString:@"zoom.us/w/"]
+                || [link containsString:@"zoomgov.com/j/"]
+                || [link containsString:@"zoomgov.com/s/"]
+                || [link containsString:@"zoomgov.com/w/"]) {
                 info.zoomURL = result.URL;
                 // Test if user has the Zoom app and, if so, create a Zoom app link.
                 if ([NSWorkspace.sharedWorkspace URLForApplicationToOpenURL:[NSURL URLWithString:@"zoommtg://"]]) {


### PR DESCRIPTION
duplicated what was done for zoom.us to add support for zoomgov.com

zoomgov.com/j/ is actually the only URL pattern that I know to be needed, /s/ and /w/ were added only because they existed for zoom.us