### PR TITLE
Ability to show or hide month border in calendar view

### DIFF
--- a/Itsycal/AppDelegate.m
+++ b/Itsycal/AppDelegate.m
@@ -37,6 +37,7 @@
         kShowMonthInIcon:      @(NO),
         kShowDayOfWeekInIcon:  @(NO),
         kShowEventDots:        @(YES),
+        kShowMonthBorder:      @(YES),
         kUseColoredDots:       @(YES),
         kThemePreference:      @0, // System=0, Light=1, Dark=2
         kHideIcon:             @(NO)

--- a/Itsycal/Itsycal.h
+++ b/Itsycal/Itsycal.h
@@ -24,5 +24,6 @@ extern NSString * const kAllowOutsideApplicationsFolder;
 extern NSString * const kClockFormat;
 extern NSString * const kHideIcon;
 extern NSString * const kShowLocation;
+extern NSString * const kShowMonthBorder;
 extern NSString * const kShowEventDots;
 extern NSString * const kUseColoredDots;

--- a/Itsycal/Itsycal.m
+++ b/Itsycal/Itsycal.m
@@ -23,5 +23,6 @@ NSString * const kAllowOutsideApplicationsFolder = @"AllowOutsideApplicationsFol
 NSString * const kClockFormat = @"ClockFormat";
 NSString * const kHideIcon = @"HideIcon";
 NSString * const kShowLocation = @"ShowLocation";
+NSString * const kShowMonthBorder = @"kShowMonthBorder";
 NSString * const kShowEventDots = @"kShowEventDots";
 NSString * const kUseColoredDots = @"UseColoredDots";

--- a/Itsycal/MoCalendar.h
+++ b/Itsycal/MoCalendar.h
@@ -57,6 +57,9 @@ typedef enum : NSInteger {
 // Should calendar show dots under days with events?
 @property (nonatomic) BOOL showEventDots;
 
+// Should calendar show border around each month?
+@property (nonatomic) BOOL showMonthBorder;
+
 // Should event dots use calendar colors?
 @property (nonatomic) BOOL useColoredDots;
 

--- a/Itsycal/MoCalendar.m
+++ b/Itsycal/MoCalendar.m
@@ -228,6 +228,12 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
     [self reloadData];
 }
 
+- (void)setShowMonthBorder:(BOOL)showMonthBorder
+{
+  _showMonthBorder = showMonthBorder;
+  [self reloadData];
+}
+
 - (void)setUseColoredDots:(BOOL)useColoredDots
 {
     _useColoredDots = useColoredDots;
@@ -806,7 +812,11 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
 
     NSBezierPath *outlinePath = [self bezierPathWithStartCell:_monthStartCell endCell:_monthEndCell radius:radius inset:0 useRects:NO];
     
-    [Theme.currentMonthOutlineColor set];
+    if (_showMonthBorder) {
+      [Theme.currentMonthOutlineColor set];
+    } else {
+      [NSColor.clearColor set];
+    }
     [outlinePath setLineWidth:1.5];
     [outlinePath stroke];
 }

--- a/Itsycal/PrefsAppearanceVC.m
+++ b/Itsycal/PrefsAppearanceVC.m
@@ -53,6 +53,7 @@
     NSButton *useColoredDots = chkbx(NSLocalizedString(@"Use colored dots", @""));
     NSButton *showWeeks = chkbx(NSLocalizedString(@"Show calendar weeks", @""));
     NSButton *showLocation = chkbx(NSLocalizedString(@"Show event location", @""));
+    NSButton *showMonthBorder = chkbx(NSLocalizedString(@"Show month border", @""));
     _hideIcon = chkbx(NSLocalizedString(@"Hide icon", @""));
 
     // Datetime format text field
@@ -108,8 +109,8 @@
     sizeSlider.maxValue = SizePreferenceLarge;  // = 2
     [v addSubview:sizeSlider];
 
-    MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20, @"mm": @40} views:NSDictionaryOfVariableBindings(menubarLabel, calendarLabel, separator0, separator1, useOutlineIcon, showMonth, showDayOfWeek, showEventDots, useColoredDots, showWeeks, showLocation, _dateTimeFormat, helpButton, _hideIcon, highlight, themeLabel, themePopup, sizeMinLabel, sizeSlider, sizeMaxLabel)];
-    [vfl :@"V:|-m-[menubarLabel]-10-[useOutlineIcon]-[showMonth]-[showDayOfWeek]-[_dateTimeFormat]-[_hideIcon]-m-[calendarLabel]-10-[sizeSlider]-15-[themePopup]-m-[highlight]-m-[showEventDots]-[useColoredDots]-[showLocation]-[showWeeks]-m-|"];
+    MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20, @"mm": @40} views:NSDictionaryOfVariableBindings(menubarLabel, calendarLabel, separator0, separator1, useOutlineIcon, showMonth, showDayOfWeek, showMonthBorder, showEventDots, useColoredDots, showWeeks, showLocation, _dateTimeFormat, helpButton, _hideIcon, highlight, themeLabel, themePopup, sizeMinLabel, sizeSlider, sizeMaxLabel)];
+    [vfl :@"V:|-m-[menubarLabel]-10-[useOutlineIcon]-[showMonth]-[showDayOfWeek]-[_dateTimeFormat]-[_hideIcon]-m-[calendarLabel]-10-[sizeSlider]-15-[themePopup]-m-[highlight]-m-[showMonthBorder]-[showEventDots]-[useColoredDots]-[showLocation]-[showWeeks]-m-|"];
     [vfl :@"H:|-m-[menubarLabel]-[separator0]-m-|" :NSLayoutFormatAlignAllCenterY];
     [vfl :@"H:|-m-[calendarLabel]-[separator1]-m-|" :NSLayoutFormatAlignAllCenterY];
     [vfl :@"H:|-m-[useOutlineIcon]-(>=m)-|"];
@@ -120,6 +121,7 @@
     [vfl :@"H:|-m-[highlight]-(>=m)-|"];
     [vfl :@"H:|-(>=m)-[sizeMinLabel]-[sizeSlider(90)]-[sizeMaxLabel]-(>=m)-|" :NSLayoutFormatAlignAllCenterY];
     [vfl :@"H:|-m-[themeLabel]-[themePopup]-(>=m)-|" :NSLayoutFormatAlignAllFirstBaseline];
+    [vfl :@"H:|-m-[showMonthBorder]-(>=m)-|"];
     [vfl :@"H:|-m-[showEventDots]-(>=m)-|"];
     [vfl :@"H:|-mm-[useColoredDots]-(>=m)-|"];
     [vfl :@"H:|-m-[showWeeks]-(>=m)-|"];
@@ -153,6 +155,9 @@
 
     // Bindings for showLocation preference
     [showLocation bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowLocation] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
+  
+    // Bindings for showMonthBorder preference
+    [showMonthBorder bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowMonthBorder] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     
     // Bindings for highlight picker
     [highlight bind:@"weekStartDOW" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kWeekStartDOW] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -146,6 +146,7 @@
     [_moCal bind:@"highlightedDOWs" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kHighlightedDOWs] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     [_moCal bind:@"weekStartDOW" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kWeekStartDOW] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
     [_agendaVC bind:@"showLocation" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowLocation] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
+    [_moCal bind:@"showMonthBorder" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowMonthBorder] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
 
     // A very ugly and questionable hack. Maybe it doesn't work. It
     // shouldn't work. But I think it might. Somehow prevents(?!?)


### PR DESCRIPTION
Add an option in settings to show / hide month border

| With border | Without border | 
| ------ | ----- |
|  <img width="234" alt="CleanShot 2022-03-21 at 17 49 39@2x" src="https://user-images.githubusercontent.com/1250691/159316270-2cd0f350-4092-4b4f-92f5-72676496700c.png"> |  <img width="239" alt="CleanShot 2022-03-21 at 17 49 24@2x" src="https://user-images.githubusercontent.com/1250691/159316567-7011bd87-4724-4413-b8b8-d11066e32824.png"> | 

### Settings page
![CleanShot 2022-03-21 at 17 56 41@2x](https://user-images.githubusercontent.com/1250691/159320634-2471e423-aaa5-49df-b720-9f0a62633baf.png)

