### PR TITLE
Fixing bug introduced in Ventura 13.0B2

### DIFF
--- a/Itsycal/EventCenter.m
+++ b/Itsycal/EventCenter.m
@@ -201,8 +201,8 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
             continue;
         }
         if (![calendar.source.title isEqualToString:currentSourceTitle]) {
-            [sourcesAndCalendars addObject:calendar.source.title];
-            currentSourceTitle = calendar.source.title;
+            [sourcesAndCalendars addObject:calendar.title];
+            currentSourceTitle = calendar.title;
         }
         CalendarInfo *calInfo = [CalendarInfo new];
         calInfo.calendar = calendar;


### PR DESCRIPTION
Firstly, thanks for the amazing project! 😃 

This is the minimal change I've needed to get Itsycal working on Ventura 13.0B2

Without this Itsycal.app is crashing on startup when there are microsoft or google calendars setup on MacOS.
(The `calendar.source.title` object was defined as `nil` for non MacOS calendars which caused a crash on line 204 within a worker thread)

Not sure exactly if this is a bug/feature/change in MacOS so don't know if there is a better fix, this was just reaching for the smallest change needed.