### PR TITLE
Show ISO dates passed to itsycal via a URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-## User settings
-**xcuserdata
-
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+## User settings
+**xcuserdata
+
+.DS_Store

--- a/Itsycal/AppDelegate.m
+++ b/Itsycal/AppDelegate.m
@@ -118,15 +118,14 @@
     if (urls.count >= 1) {
         NSURL *url = urls[0];
         if ([url.host isEqualToString:@"date"] && url.pathComponents.count == 2) {
-            NSISO8601DateFormatter *format = [NSISO8601DateFormatter new];
-            format.formatOptions = NSISO8601DateFormatWithFullDate | NSISO8601DateFormatWithDashSeparatorInDate;
+            NSDateFormatter *format = [NSDateFormatter new];
+            format.dateFormat = @"yyyy-MM-dd";
             NSDate *date = [format dateFromString:url.pathComponents[1]];
             
             if (date) {
                 [(ViewController *)_wc.contentViewController dateURLReceived:date];
             } else if ([url.pathComponents[1] isEqualToString:@"now"]) {
-                date = [NSDate new];
-                [(ViewController *)_wc.contentViewController dateURLReceived:date];
+                [(ViewController *)_wc.contentViewController dateURLReceived:[NSDate new]];
             }
         }
     }

--- a/Itsycal/AppDelegate.m
+++ b/Itsycal/AppDelegate.m
@@ -116,16 +116,21 @@
 - (void)application:(NSApplication *)application openURLs:(NSArray<NSURL *> *)urls
 {
     if (urls.count >= 1) {
+        // We can only handle showing one date at a time, so we pick the first one
         NSURL *url = urls[0];
         if ([url.host isEqualToString:@"date"] && url.pathComponents.count == 2) {
-            NSDateFormatter *format = [NSDateFormatter new];
-            format.dateFormat = @"yyyy-MM-dd";
-            NSDate *date = [format dateFromString:url.pathComponents[1]];
+            NSString *dateString = url.pathComponents[1];
             
-            if (date) {
-                [(ViewController *)_wc.contentViewController dateURLReceived:date];
-            } else if ([url.pathComponents[1] isEqualToString:@"now"]) {
+            if ([dateString isEqualToString:@"now"]) {
                 [(ViewController *)_wc.contentViewController dateURLReceived:[NSDate new]];
+            } else {
+                NSDateFormatter *format = [NSDateFormatter new];
+                format.dateFormat = @"yyyy-MM-dd";
+                NSDate *date = [format dateFromString:dateString];
+                
+                if (date) {
+                    [(ViewController *)_wc.contentViewController dateURLReceived:date];
+                }
             }
         }
     }

--- a/Itsycal/AppDelegate.m
+++ b/Itsycal/AppDelegate.m
@@ -113,6 +113,25 @@
     [[MASShortcutMonitor sharedMonitor] unregisterAllShortcuts];
 }
 
+- (void)application:(NSApplication *)application openURLs:(NSArray<NSURL *> *)urls
+{
+    if (urls.count >= 1) {
+        NSURL *url = urls[0];
+        if ([url.host isEqualToString:@"date"] && url.pathComponents.count == 2) {
+            NSISO8601DateFormatter *format = [NSISO8601DateFormatter new];
+            format.formatOptions = NSISO8601DateFormatWithFullDate | NSISO8601DateFormatWithDashSeparatorInDate;
+            NSDate *date = [format dateFromString:url.pathComponents[1]];
+            
+            if (date) {
+                [(ViewController *)_wc.contentViewController dateURLReceived:date];
+            } else if ([url.pathComponents[1] isEqualToString:@"now"]) {
+                date = [NSDate new];
+                [(ViewController *)_wc.contentViewController dateURLReceived:date];
+            }
+        }
+    }
+}
+
 #pragma mark -
 #pragma mark Applications folder check
 

--- a/Itsycal/Info.plist
+++ b/Itsycal/Info.plist
@@ -24,6 +24,19 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.mowglii.ItsycalApp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>itsycal</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
@@ -34,10 +47,10 @@
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Itsycal uses AppleEvents to open your calendar app to the selected day. You can change this setting in System Preferences › Security &amp; Privacy › Privacy</string>
-	<key>NSCalendarsUsageDescription</key>
-	<string>Itsycal is more useful when it can display events from your calendars. You can change this setting in System Preferences › Security &amp; Privacy › Privacy</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Itsycal is more useful when it can display events from your calendars. You can change this setting in System Settings › Privacy &amp; Security › Calendars</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Itsycal is more useful when it can display events from your calendars. You can change this setting in System Preferences › Security &amp; Privacy › Privacy</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2012 − 2023 mowglii.com</string>
 	<key>NSMainNibFile</key>
@@ -50,9 +63,9 @@
 	<true/>
 	<key>SUFeedURL</key>
 	<string>https://s3.amazonaws.com/itsycal/itsycal.xml</string>
-	<key>SUScheduledCheckInterval</key>
-	<real>345600</real>
 	<key>SUPublicEDKey</key>
 	<string>TxKIjUS10OYKgZaAQlRvDjFNEc28hG82wtRWlcNUYSc=</string>
+	<key>SUScheduledCheckInterval</key>
+	<real>345600</real>
 </dict>
 </plist>

--- a/Itsycal/ViewController.h
+++ b/Itsycal/ViewController.h
@@ -16,5 +16,6 @@
 
 - (void)keyboardShortcutActivated;
 - (void)removeStatusItem;
+- (void)dateURLReceived:(NSDate *)showDate;
 
 @end

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -404,9 +404,15 @@
 
 - (void)openDateAndTimePrefs:(id)sender
 {
-    // Can this be done without hardcoding a path?
-    NSString *path = @"/System/Library/PreferencePanes/DateAndTime.prefPane";
-    NSURL *url = [NSURL fileURLWithPath:path];
+    NSURL *url = nil;
+    
+    if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_13) {
+        url = [NSURL URLWithString:@"x-apple.systempreferences:com.apple.Date-Time-Settings.extension"];
+    } else {
+        NSString *path = @"/System/Library/PreferencePanes/DateAndTime.prefPane";
+        url = [NSURL fileURLWithPath:path];
+    }
+    
     [NSWorkspace.sharedWorkspace openURL:url];
 }
 

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -406,7 +406,7 @@
 {
     NSURL *url = nil;
     
-    if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_13) {
+    if (@available(macOS 13, *)) {
         url = [NSURL URLWithString:@"x-apple.systempreferences:com.apple.Date-Time-Settings.extension"];
     } else {
         NSString *path = @"/System/Library/PreferencePanes/DateAndTime.prefPane";

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -404,16 +404,9 @@
 
 - (void)openDateAndTimePrefs:(id)sender
 {
-    NSURL *url = nil;
-    
-    if (@available(macOS 13, *)) {
-        url = [NSURL URLWithString:@"x-apple.systempreferences:com.apple.Date-Time-Settings.extension"];
-    } else {
-        NSString *path = @"/System/Library/PreferencePanes/DateAndTime.prefPane";
-        url = [NSURL fileURLWithPath:path];
-    }
-    
-    [NSWorkspace.sharedWorkspace openURL:url];
+    // Can this be done without hardcoding a path?
+    NSString *path = @"/System/Library/PreferencePanes/DateAndTime.prefPane";
+    NSURL *url = [NSURL fileURLWithPath:path];
 }
 
 - (void)navigateToHelp:(id)sender

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -407,6 +407,7 @@
     // Can this be done without hardcoding a path?
     NSString *path = @"/System/Library/PreferencePanes/DateAndTime.prefPane";
     NSURL *url = [NSURL fileURLWithPath:path];
+    [NSWorkspace.sharedWorkspace openURL:url];
 }
 
 - (void)navigateToHelp:(id)sender

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -839,6 +839,20 @@
     [self statusItemClicked:self];
 }
 
+- (void)dateURLReceived:(NSDate *)showDate
+{
+    // We received a URL asking us to show a specific date.
+    MoDate selectedDate = MakeDateWithNSDate(showDate, _nsCal);
+    _moCal.selectedDate = selectedDate;
+    
+    // Only "click" the status item if the itsycal window isn't already visible.
+    // Otherwise, it would just close.
+    if (!([self.itsycalWindow occlusionState] & NSWindowOcclusionStateVisible)) {
+        [self statusItemClicked:self];
+    }
+
+}
+
 #pragma mark -
 #pragma mark AgendaDelegate
 


### PR DESCRIPTION
Open Terminal and issue this command:

```
open itsycal://date/1969-07-20
```

With this PR, it will open the Itsycal menu item with the specified date selected. You can also open it to the current day by passing `date/now`.