### PR TITLE
Add project .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 ## User settings
-**xcuserdata
+xcuserdata/
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+## User settings
+**xcuserdata
+
+.DS_Store


### PR DESCRIPTION
Anyone who commits to this repo is going to see .DS_Store and xcuserdata files unless they _also_ have this in their global `.gitingore`. I, for one, didn't, so I was in danger of committing the wrong files.

I'd argue that, for a one-person project, using global ignore rules is fine. But once you have a shared repo, it's best to make it as easy as possible to contribute to the project in The Right Way. So being explicit about the project's ignore rules is a good idea.

I've based this PR on [the GitHub template](https://github.com/github/gitignore/blob/main/Objective-C.gitignore).