### PR TITLE
Add support for VK Calls` links

### DIFF
--- a/Itsycal/EventCenter.m
+++ b/Itsycal/EventCenter.m
@@ -439,7 +439,8 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
                      || [link containsString:@"public.senfcall.de"]
                      || [link containsString:@"facetime.apple.com/join"]
                      || [link containsString:@"workplace.com/meet"]
-                     || [link containsString:@"youcanbook.me/zoom/"]) {
+                     || [link containsString:@"youcanbook.me/zoom/"]
+                     || [link containsString:@"vk.com/call/"]) {
                 info.zoomURL = result.URL;
             }
             *stop = info.zoomURL != nil;


### PR DESCRIPTION
[VK Calls](https://calls.vk.com/) is equivalent for Zoom and other apps for online calls. Links for this app look like this:

`https://vk.com/call/join/A-VGBY2N31NAmW41HIbGE7pCn5C-VVTjxz27sqb31SU`

I've added support for this type of links.

This PR fixes #216.