### PR TITLE
Fix agenda popover always being closed on hover events

### DIFF
--- a/Itsycal/AgendaViewController.m
+++ b/Itsycal/AgendaViewController.m
@@ -414,7 +414,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     BOOL showPopoverOnHover = [[NSUserDefaults standardUserDefaults] boolForKey:kShowEventPopoverOnHover];
     if (hoveredRow == -1 || [self tableView:_tv isGroupRow:hoveredRow] ||
         [self tableView:_tv isEmptyEventRow:hoveredRow]) {
-        if (kShowEventPopoverOnHover && hoveredRow != -1) {
+        if (showPopoverOnHover && hoveredRow != -1) {
             [_popover close];
         }
         hoveredRow = -1;


### PR DESCRIPTION
Hi!

0.15.5 introduced a terminal-only `ShowEventPopoverOnHover` option, which opens and closes the event agenda popovers on hover in and out events, but there is a bug causing a part of that behavior to leak into the default mode when this property is either disabled or not set.

`kShowEventPopoverOnHover` is an `NSCFConstantString` instance and is a truthy value, so this code path is always taken and the popover closes when it should only react to explicit interactions.


https://github.com/user-attachments/assets/4982e07f-b033-4396-b7b9-20ceeae1c802

I assume the intention was to use the extracted boolean value for the flag instead, which indeed fixes the problem, this PR does just that.

Thanks!