### PR TITLE
Add support for MAX Calls event

### DIFF
--- a/Itsycal/EventCenter.m
+++ b/Itsycal/EventCenter.m
@@ -440,7 +440,8 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
                      || [link containsString:@"facetime.apple.com/join"]
                      || [link containsString:@"workplace.com/meet"]
                      || [link containsString:@"youcanbook.me/zoom/"]
-                     || [link containsString:@"vk.com/call/"]) {
+                     || [link containsString:@"vk.com/call/"])
+                     || [link containsString:@"max.ru/joincall/"]) {
                 info.zoomURL = result.URL;
             }
             *stop = info.zoomURL != nil;


### PR DESCRIPTION
MAX is another messenger with calls. Links for this app look like this:

`https://max.ru/joincall/0Ahimzg6m_hdoacYx7AiIB4HLi6FeijjTkCfXVh25X4`

I've added support for this type of links.