### PR TITLE
Anniversary events to Itsycal from contact detail

### DIFF
--- a/Itsycal.xcodeproj/project.pbxproj
+++ b/Itsycal.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3660790F2F413E99008E7160 /* ContactEventManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3660790E2F413E99008E7160 /* ContactEventManager.m */; };
+		366079112F413FA4008E7160 /* ContactEventManager.h in Sources */ = {isa = PBXBuildFile; fileRef = 366079102F413F5B008E7160 /* ContactEventManager.h */; };
 		920B5D7C2B4D10B6004A10D3 /* DatePickerVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 920B5D7B2B4D10B6004A10D3 /* DatePickerVC.m */; };
 		920D6D51266A83AC00498E19 /* MoLoginItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 920D6D4F266A83AC00498E19 /* MoLoginItem.m */; };
 		921181C722E0192A00591FDA /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 921181C622E0192A00591FDA /* Colors.xcassets */; };
@@ -75,6 +77,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3660790E2F413E99008E7160 /* ContactEventManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ContactEventManager.m; sourceTree = "<group>"; };
+		366079102F413F5B008E7160 /* ContactEventManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContactEventManager.h; sourceTree = "<group>"; };
 		6F21F6F31F0CDA7D00F443BE /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		6F21F6F41F0CDA7D00F443BE /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		6F21F6F51F0CDA7D00F443BE /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -257,7 +261,9 @@
 				9261EB2E1EEF447500DCFFC4 /* Themer.h */,
 				9261EB2F1EEF447500DCFFC4 /* Themer.m */,
 				92B28CCD210BD17500485AE2 /* Sizer.h */,
+				366079102F413F5B008E7160 /* ContactEventManager.h */,
 				92B28CCE210BD17500485AE2 /* Sizer.m */,
+				3660790E2F413E99008E7160 /* ContactEventManager.m */,
 			);
 			path = Itsycal;
 			sourceTree = "<group>";
@@ -346,7 +352,6 @@
 				TargetAttributes = {
 					9242A55B1A82A136005AA4B3 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = HFT3T55WND;
 						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.HardenedRuntime = {
@@ -439,6 +444,8 @@
 				9261EB301EEF447500DCFFC4 /* Themer.m in Sources */,
 				922B6BBB1A85E0EC00DEA9CD /* MoTextField.m in Sources */,
 				9215AD4C1E3AECA700317FAE /* MoVFLHelper.m in Sources */,
+				366079112F413FA4008E7160 /* ContactEventManager.h in Sources */,
+				3660790F2F413E99008E7160 /* ContactEventManager.m in Sources */,
 				9242A5901A82A40B005AA4B3 /* MoDate.m in Sources */,
 				925B471B1A93CD2A00E0329A /* TooltipViewController.m in Sources */,
 				921E62D01E26B9D2007B029F /* PrefsAppearanceVC.m in Sources */,
@@ -613,6 +620,7 @@
 				CURRENT_PROJECT_VERSION = 2350;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = HFT3T55WND;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = YW2WSR36CA;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -641,6 +649,7 @@
 				CURRENT_PROJECT_VERSION = 2350;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = HFT3T55WND;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = YW2WSR36CA;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Itsycal/AppDelegate.m
+++ b/Itsycal/AppDelegate.m
@@ -41,6 +41,7 @@
         kThemePreference:      @0, // System=0, Light=1, Dark=2
         kHideIcon:             @(NO),
         kShowLocation:         @(NO),
+        kShowContactEvents:    @(YES), // Show contact anniversaries and birthdays
         kDoNotDrawOutlineAroundCurrentMonth: @(NO)
     }];
     

--- a/Itsycal/ContactEventManager.h
+++ b/Itsycal/ContactEventManager.h
@@ -1,0 +1,36 @@
+//
+//  ContactEventManager.h
+//  Itsycal
+//
+//  Created by Mr.Buch on 2/15/26.
+//  Manages contact dates (birthdays, anniversaries, etc.) as calendar events
+//
+
+#import <Foundation/Foundation.h>
+#import <Contacts/Contacts.h>
+#import "MoDate.h"
+
+@class EventInfo;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ContactEventManager : NSObject
+
+// Did the user grant contacts access?
+@property (nonatomic, readonly) BOOL contactsAccessGranted;
+
+- (instancetype)initWithCalendar:(NSCalendar *)calendar;
+
+// Request access to contacts
+- (void)requestContactsAccessWithCompletion:(void (^)(BOOL granted))completion;
+
+// Fetch contact dates for a date range and return as EventInfo objects via completion handler
+// Completion handler receives a dictionary mapping NSDate -> NSArray<EventInfo *>
+// This method is asynchronous and performs work on a background queue
+- (void)contactEventsFromDate:(MoDate)startDate 
+                        toDate:(MoDate)endDate
+                    completion:(void (^)(NSDictionary<NSDate *, NSArray<EventInfo *> *> *events))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Itsycal/ContactEventManager.m
+++ b/Itsycal/ContactEventManager.m
@@ -1,0 +1,271 @@
+//
+//  ContactEventManager.m
+//  Itsycal
+//
+//  Created by Mr.Buch on 2/15/26.
+//  Manages contact dates (birthdays, anniversaries, etc.) as calendar events
+//
+
+#import "ContactEventManager.h"
+#import "EventCenter.h"
+#import "MoDate.h"
+#import <Contacts/Contacts.h>
+#import <AppKit/AppKit.h>
+
+@implementation ContactEventManager {
+    CNContactStore *_contactStore;
+    NSCalendar *_calendar;
+}
+
+- (instancetype)initWithCalendar:(NSCalendar *)calendar {
+    self = [super init];
+    if (self) {
+        _calendar = calendar;
+        _contactStore = [[CNContactStore alloc] init];
+    }
+    return self;
+}
+
+- (BOOL)contactsAccessGranted {
+    CNAuthorizationStatus status = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
+    return status == CNAuthorizationStatusAuthorized;
+}
+
+- (void)requestContactsAccessWithCompletion:(void (^)(BOOL granted))completion {
+    CNAuthorizationStatus status = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
+    
+    if (status == CNAuthorizationStatusAuthorized) {
+        if (completion) completion(YES);
+        return;
+    }
+    
+    if (status == CNAuthorizationStatusNotDetermined) {
+        NSLog(@"[ContactEventManager] Requesting contacts access...");
+        [_contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError * _Nullable error) {
+            if (completion) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completion(granted);
+                });
+            }
+        }];
+    } else {
+        NSLog(@"[ContactEventManager] Contacts access denied or restricted (status: %ld)", (long)status);
+        if (completion) completion(NO);
+    }
+}
+
+- (void)contactEventsFromDate:(MoDate)startDate
+                        toDate:(MoDate)endDate
+                    completion:(void (^)(NSDictionary<NSDate *, NSArray<EventInfo *> *> *events))completion {
+    if (![self contactsAccessGranted]) {
+        NSLog(@"[ContactEventManager] Contacts access NOT granted. Cannot fetch events.");
+        if (completion) {
+            completion(@{});
+        }
+        return;
+    }
+    
+    // Perform the synchronous fetch on a utility queue to match EventCenter's QoS
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        NSDictionary *events = [self _fetchContactEventsFromDate:startDate toDate:endDate];
+        if (completion) {
+            completion(events);
+        }
+    });
+}
+
+- (NSDictionary<NSDate *, NSArray<EventInfo *> *> *)_fetchContactEventsFromDate:(MoDate)startDate
+                                                                          toDate:(MoDate)endDate {
+    NSLog(@"[ContactEventManager] Contacts access granted. Fetching contact dates...");
+    
+    NSMutableDictionary<NSDate *, NSMutableArray<EventInfo *> *> *eventsForDate = [NSMutableDictionary dictionary];
+    
+    // Get the years we need to fetch for
+    NSDateComponents *startComponents = [_calendar components:NSCalendarUnitYear fromDate:MakeNSDateWithDate(startDate, _calendar)];
+    NSDateComponents *endComponents = [_calendar components:NSCalendarUnitYear fromDate:MakeNSDateWithDate(endDate, _calendar)];
+    
+    NSInteger startYear = startComponents.year;
+    NSInteger endYear = endComponents.year;
+    
+    // Fetch contacts and process their dates
+    NSError *error = nil;
+    NSArray *keysToFetch = @[
+        CNContactGivenNameKey,
+        CNContactFamilyNameKey,
+        CNContactNicknameKey,
+        CNContactBirthdayKey,
+        CNContactDatesKey,
+        CNContactImageDataAvailableKey
+    ];
+    
+    CNContactFetchRequest *request = [[CNContactFetchRequest alloc] initWithKeysToFetch:keysToFetch];
+    
+    __block NSInteger contactCount = 0;
+    
+    // Enumerate contacts - this is synchronous but we're on an appropriate QoS queue now
+    [_contactStore enumerateContactsWithFetchRequest:request error:&error usingBlock:^(CNContact * _Nonnull contact, BOOL * _Nonnull stop) {
+        contactCount++;
+        NSString *displayName = [self displayNameForContact:contact];
+        
+        // Process birthday
+        if (contact.birthday) {
+            [self addEventsForDateComponents:contact.birthday
+                                        name:displayName
+                                       label:@"Birthday"
+                                       emoji:@"🎂"
+                                   startYear:startYear
+                                     endYear:endYear
+                                  startMoDate:startDate
+                                    endMoDate:endDate
+                               eventsForDate:eventsForDate];
+        }
+        
+        // Process anniversaries and other dates
+        for (CNLabeledValue<NSDateComponents *> *labeledDate in contact.dates) {
+            NSString *label = [self labelStringForLabel:labeledDate.label];
+            NSString *emoji = [self emojiForLabel:labeledDate.label];
+            
+            [self addEventsForDateComponents:labeledDate.value
+                                        name:displayName
+                                       label:label
+                                       emoji:emoji
+                                   startYear:startYear
+                                     endYear:endYear
+                                  startMoDate:startDate
+                                    endMoDate:endDate
+                               eventsForDate:eventsForDate];
+        }
+    }];
+    
+    if (error) {
+        NSLog(@"[ContactEventManager] Error fetching contacts: %@", error);
+        return @{};
+    }
+    
+    
+    return eventsForDate;
+}
+
+- (void)addEventsForDateComponents:(NSDateComponents *)dateComponents
+                              name:(NSString *)name
+                             label:(NSString *)label
+                             emoji:(NSString *)emoji
+                         startYear:(NSInteger)startYear
+                           endYear:(NSInteger)endYear
+                        startMoDate:(MoDate)startMoDate
+                          endMoDate:(MoDate)endMoDate
+                     eventsForDate:(NSMutableDictionary<NSDate *, NSMutableArray<EventInfo *> *> *)eventsForDate {
+    
+    if (!dateComponents || !dateComponents.month || !dateComponents.day) {
+        return; // Invalid date components
+    }
+    
+    // Create events for each year in the range
+    for (NSInteger year = startYear; year <= endYear; year++) {
+        NSDateComponents *eventComponents = [[NSDateComponents alloc] init];
+        eventComponents.year = year;
+        eventComponents.month = dateComponents.month;
+        eventComponents.day = dateComponents.day;
+        eventComponents.hour = 0;
+        eventComponents.minute = 0;
+        eventComponents.second = 0;
+        
+        NSDate *eventDate = [_calendar dateFromComponents:eventComponents];
+        if (!eventDate) continue;
+        
+        // Check if this date falls within our range
+        MoDate eventMoDate = MakeDateWithNSDate(eventDate, _calendar);
+        if (eventMoDate.julian < startMoDate.julian || eventMoDate.julian > endMoDate.julian) {
+            continue;
+        }
+        
+        // Calculate age/years if original year is known
+        NSString *title;
+        if (dateComponents.year && dateComponents.year != NSDateComponentUndefined) {
+            NSInteger yearsCount = year - dateComponents.year;
+            if (yearsCount > 0) {
+                title = [NSString stringWithFormat:@"%@ %@'s %@ (%ld)", emoji, name, label, (long)yearsCount];
+            } else {
+                title = [NSString stringWithFormat:@"%@ %@'s %@", emoji, name, label];
+            }
+        } else {
+            title = [NSString stringWithFormat:@"%@ %@'s %@", emoji, name, label];
+        }
+        
+        // Create EventInfo for contact event
+        EventInfo *info = [[EventInfo alloc] init];
+        info.event = nil; // No actual calendar event
+        info.isContactEvent = YES;
+        info.contactEventTitle = title;
+        info.contactEventDate = eventDate;
+        info.contactEventColor = [self colorForLabel:label]; // Use a distinct color for contact events
+        info.isStartDate = YES;
+        info.isEndDate = YES;
+        info.isAllDay = YES;
+        
+        // Add to dictionary
+        NSDate *startOfDay = [_calendar startOfDayForDate:eventDate];
+        if (!eventsForDate[startOfDay]) {
+            eventsForDate[startOfDay] = [NSMutableArray array];
+        }
+        [eventsForDate[startOfDay] addObject:info];
+    }
+}
+
+- (NSString *)displayNameForContact:(CNContact *)contact {
+    if (contact.givenName.length > 0 && contact.familyName.length > 0) {
+        return [NSString stringWithFormat:@"%@ %@", contact.givenName, contact.familyName];
+    } else if (contact.givenName.length > 0) {
+        return contact.givenName;
+    } else if (contact.familyName.length > 0) {
+        return contact.familyName;
+    } else if (contact.nickname.length > 0) {
+        return contact.nickname;
+    }
+    return @"Unknown Contact";
+}
+
+- (NSString *)labelStringForLabel:(NSString *)label {
+    if ([label isEqualToString:CNLabelDateAnniversary]) {
+        return @"Anniversary";
+    } else if ([label isEqualToString:CNLabelHome]) {
+        return @"Home Date";
+    } else if ([label isEqualToString:CNLabelWork]) {
+        return @"Work Date";
+    } else if ([label isEqualToString:CNLabelOther]) {
+        return @"Other Date";
+    }
+    
+    // Try to localize the label
+    NSString *localizedLabel = [CNLabeledValue localizedStringForLabel:label];
+    if (localizedLabel && ![localizedLabel isEqualToString:label]) {
+        return localizedLabel;
+    }
+    
+    // Remove prefix if present (e.g., "_$!<Anniversary>!$_" -> "Anniversary")
+    if ([label hasPrefix:@"_$!<"] && [label hasSuffix:@">!$_"]) {
+        return [label substringWithRange:NSMakeRange(4, label.length - 8)];
+    }
+    
+    return label;
+}
+
+- (NSString *)emojiForLabel:(NSString *)label {
+    if ([label isEqualToString:CNLabelDateAnniversary]) {
+        return @"💍";
+    } else if ([label containsString:@"Wedding"]) {
+        return @"💒";
+    } else if ([label containsString:@"Engagement"]) {
+        return @"💍";
+    } else if ([label containsString:@"Relationship"]) {
+        return @"❤️";
+    }
+    return @"📅";
+}
+
+- (NSColor *)colorForLabel:(NSString *)label {
+    // Use a purple/magenta color for contact events to distinguish from calendar events
+    return [NSColor colorWithRed:0.8 green:0.4 blue:0.8 alpha:1.0];
+}
+
+@end

--- a/Itsycal/EventCenter.h
+++ b/Itsycal/EventCenter.h
@@ -10,6 +10,8 @@
 #import <EventKit/EventKit.h>
 #import "MoDate.h"
 
+@class ContactEventManager;
+
 // =========================================================================
 // EventCenter
 // Provide calendar and event data.
@@ -24,12 +26,18 @@
 
 @property (nonatomic, readonly) NSString *defaultCalendarIdentifier;
 
+// Contact event manager
+@property (nonatomic, readonly) ContactEventManager *contactEventManager;
+
 // Delegate is responsible for...
 @property (nonatomic, weak) id<EventCenterDelegate> delegate;
 
 - (instancetype)initWithCalendar:(NSCalendar *)calendar delegate:(id<EventCenterDelegate>)delegate;
 
 - (EKEvent *)newEvent;
+
+// Refresh an event from the event store to restore its connection
+- (EKEvent *)refreshEvent:(EKEvent *)event;
 
 - (BOOL)saveEvent:(EKEvent *)event error:(NSError **)error;
 
@@ -94,4 +102,11 @@
 @property (nonatomic) BOOL isEndDate;   // event ends, but doesn't start, on this date
 @property (nonatomic) BOOL isAllDay;    // event is all-day, or spans across this date
 @property (nonatomic) NSURL *zoomURL;   // Zoom, Google Meet, Microsoft Teams, etc. URL
+
+// Contact event properties (used when event is nil)
+@property (nonatomic) BOOL isContactEvent;
+@property (nonatomic) NSString *contactEventTitle;
+@property (nonatomic) NSDate *contactEventDate;
+@property (nonatomic) NSColor *contactEventColor;
+
 @end

--- a/Itsycal/Info.plist
+++ b/Itsycal/Info.plist
@@ -51,7 +51,9 @@
 	<string>Itsycal is more useful when it can display events from your calendars. You can change this setting in System Settings › Privacy &amp; Security › Calendars</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Itsycal is more useful when it can display events from your calendars. You can change this setting in System Preferences › Security &amp; Privacy › Privacy</string>
-	<key>NSHumanReadableCopyright</key>
+    <key>NSContactsUsageDescription</key>
+    <string>Itsycal would like to access your contacts to display birthdays, anniversaries, and other important dates in the calendar.</string>
+    <key>NSHumanReadableCopyright</key>
 	<string>© 2012 − 2025 mowglii.com</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>

--- a/Itsycal/Itsycal.entitlements
+++ b/Itsycal/Itsycal.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
 </dict>
 </plist>

--- a/Itsycal/Itsycal.h
+++ b/Itsycal/Itsycal.h
@@ -33,6 +33,7 @@ extern NSString * const kEnableMeetingButtonIndefinitely;
 extern NSString * const kDoNotDrawOutlineAroundCurrentMonth;
 extern NSString * const kShowDaysWithNoEventsInAgenda;
 extern NSString * const kShowEventPopoverOnHover;
+extern NSString * const kShowContactEvents;
 
 // Set an associated object on NSDate to indicate
 // whether of not this date has events.

--- a/Itsycal/Itsycal.m
+++ b/Itsycal/Itsycal.m
@@ -31,3 +31,4 @@ NSString * const kEnableMeetingButtonIndefinitely = @"EnableMeetingButtonIndefin
 NSString * const kDoNotDrawOutlineAroundCurrentMonth = @"DoNotDrawOutlineAroundCurrentMonth";
 NSString * const kShowDaysWithNoEventsInAgenda = @"ShowDaysWithNoEventsInAgenda";
 NSString * const kShowEventPopoverOnHover = @"ShowEventPopoverOnHover";
+NSString * const kShowContactEvents = @"ShowContactEvents";

--- a/Itsycal/PrefsAppearanceVC.m
+++ b/Itsycal/PrefsAppearanceVC.m
@@ -5,6 +5,7 @@
 
 #import "PrefsAppearanceVC.h"
 #import "Itsycal.h"
+#import "EventCenter.h"
 #import "HighlightPicker.h"
 #import "MoVFLHelper.h"
 #import "Themer.h"
@@ -16,6 +17,7 @@
 {
     NSTextField *_dateTimeFormat;
     NSButton *_hideIcon;
+    NSButton *_showContactEvents;
 }
 
 #pragma mark -
@@ -64,6 +66,8 @@
     NSButton *showWeeks = chkbx(NSLocalizedString(@"Show calendar weeks", @""));
     NSButton *showLocation = chkbx(NSLocalizedString(@"Show event location", @""));
     NSButton *showDaysWithoutEvents = chkbx(NSLocalizedString(@"Show days with no events", @""));
+    _showContactEvents = chkbx(NSLocalizedString(@"Show contact birthdays and anniversaries", @""));
+    _showContactEvents.action = @selector(showContactEventsChanged:);
     _hideIcon = chkbx(NSLocalizedString(@"Hide icon", @""));
 
     // Datetime format text field
@@ -119,8 +123,8 @@
     sizeSlider.maxValue = SizePreferenceLarge;  // = 2
     [v addSubview:sizeSlider];
 
-    MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20, @"mm": @40} views:NSDictionaryOfVariableBindings(iconPicker, menubarLabel, calendarLabel, separator0, separator1, showMonth, showDayOfWeek, showEventDots, useColoredDots, showWeeks, showLocation, showDaysWithoutEvents, _dateTimeFormat, helpButton, _hideIcon, highlight, themeLabel, themePopup, sizeMinLabel, sizeSlider, sizeMaxLabel)];
-    [vfl :@"V:|-m-[menubarLabel]-10-[iconPicker]-[showMonth]-[showDayOfWeek]-[_dateTimeFormat]-[_hideIcon]-m-[calendarLabel]-10-[sizeSlider]-15-[themePopup]-m-[highlight]-m-[showEventDots]-[useColoredDots]-[showLocation]-[showDaysWithoutEvents]-[showWeeks]-m-|"];
+    MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:v metrics:@{@"m": @20, @"mm": @40} views:NSDictionaryOfVariableBindings(iconPicker, menubarLabel, calendarLabel, separator0, separator1, showMonth, showDayOfWeek, showEventDots, useColoredDots, showWeeks, showLocation, showDaysWithoutEvents, _showContactEvents, _dateTimeFormat, helpButton, _hideIcon, highlight, themeLabel, themePopup, sizeMinLabel, sizeSlider, sizeMaxLabel)];
+    [vfl :@"V:|-m-[menubarLabel]-10-[iconPicker]-[showMonth]-[showDayOfWeek]-[_dateTimeFormat]-[_hideIcon]-m-[calendarLabel]-10-[sizeSlider]-15-[themePopup]-m-[highlight]-m-[showEventDots]-[useColoredDots]-[showLocation]-[showDaysWithoutEvents]-[showWeeks]-[_showContactEvents]-m-|"];
     [vfl :@"H:|-m-[menubarLabel]-[separator0]-m-|" :NSLayoutFormatAlignAllCenterY];
     [vfl :@"H:|-m-[calendarLabel]-[separator1]-m-|" :NSLayoutFormatAlignAllCenterY];
     [vfl :@"H:|-m-[iconPicker]-m-|"];
@@ -136,6 +140,7 @@
     [vfl :@"H:|-m-[showWeeks]-(>=m)-|"];
     [vfl :@"H:|-m-[showLocation]-(>=m)-|"];
     [vfl :@"H:|-m-[showDaysWithoutEvents]-(>=m)-|"];
+    [vfl :@"H:|-m-[_showContactEvents]-(>=m)-|"];
 
     [v.centerXAnchor constraintEqualToAnchor:sizeSlider.centerXAnchor].active = YES;
 
@@ -173,6 +178,9 @@
     
     // Bindings for showDaysWithoutEvents preference
     [showDaysWithoutEvents bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowDaysWithNoEventsInAgenda] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
+
+    // Binding for show contact events
+    [_showContactEvents bind:@"value" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowContactEvents] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
 
     // Bindings for highlight picker
     [highlight bind:@"weekStartDOW" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kWeekStartDOW] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
@@ -233,6 +241,12 @@
 - (void)didChangeHighlight:(HighlightPicker *)picker
 {
     [[NSUserDefaults standardUserDefaults] setInteger:picker.selectedDOWs forKey:kHighlightedDOWs];
+}
+
+- (void)showContactEventsChanged:(NSButton *)checkbox
+{
+    // When the user toggles contact events, we need to refetch events
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ContactEventsPreferenceChanged" object:nil];
 }
 
 @end


### PR DESCRIPTION
macOS Birthdays calendar only shows birthdates from Contacts — it completely ignores anniversary dates and other labeled dates stored on a contact.

This means if you have a wedding anniversary saved in Contacts, there's no way to see it in any calendar view without manually creating a recurring event yourself.

This change pulls those dates directly from Contacts and shows them alongside regular calendar events in Itsycal.

<img width="315" height="579" alt="setting" src="https://github.com/user-attachments/assets/a6bae6ab-dd44-4db6-a3f6-9e77fff654b3" />
