### PR TITLE
Fix window position when icon isn't visible

### DIFF
--- a/Itsycal.xcodeproj/project.pbxproj
+++ b/Itsycal.xcodeproj/project.pbxproj
@@ -346,6 +346,7 @@
 				TargetAttributes = {
 					9242A55B1A82A136005AA4B3 = {
 						CreatedOnToolsVersion = 6.1.1;
+						DevelopmentTeam = HFT3T55WND;
 						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.HardenedRuntime = {
@@ -612,7 +613,6 @@
 				CURRENT_PROJECT_VERSION = 2350;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = HFT3T55WND;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 6XWJB5YJ6J;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -641,7 +641,6 @@
 				CURRENT_PROJECT_VERSION = 2350;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = HFT3T55WND;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 6XWJB5YJ6J;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
# Context

Itsycal doesn't currently do well in situations when the menubar icon isn't visible. This can be the case either because there isn't enough space in the menubar for the icon, or because the user is using a menubar management app to hide it.

- When there isn't enough space, the icon is invisible but still positioned to the left of the visible ones: as a result, Itsycal show its window pointing to one of the frontmost app's main menus.
- When the icon was purposefully hidden (I tested with Ice.app), the icon's location is far off-screen, and as a result, the Itsycal window doesn't show at all.

# Fix

This commit detects both cases of icon invisibility, and falls back to positioning the window against the right edge of the screen.

# Details

I tested a few cases (one screen, two screens; not enough space, icon hidden with Ice.app) but there might be more that I didn't expect.

There's no explicit code to handle the arrow view, because it seems to disappear automatically when the target frame is too far to the side; I think this is the right behavior here.

I tried matching the existing code style; please feel free to suggest/make changes to the code or its formatting or the comments, of course!