### PR TITLE
Fix observer lifecycle and tooltip warning

### DIFF
--- a/Itsycal/MoCalToolTipWC.m
+++ b/Itsycal/MoCalToolTipWC.m
@@ -73,7 +73,7 @@
 - (void)showTooltip
 {
     [self positionTooltip];
-    [self showWindow:self];
+    [self.window orderFront:nil];
     [self.window setAlphaValue:1];
 }
 

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -42,16 +42,24 @@
     BOOL       _shouldShowMeetingIndicator;
     NSRect     _screenFrame;
     NSPopover *_newEventPopover;
+    NSMutableArray *_notificationTokens;
 }
 
 - (void)dealloc
 {
+    for (id token in _notificationTokens) {
+        [[NSNotificationCenter defaultCenter] removeObserver:token];
+        [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:token];
+    }
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowEventDays];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kMenuBarIconType];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowMonthInIcon];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowDayOfWeekInIcon];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowDaysWithNoEventsInAgenda];
+    [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowMeetingIndicator];
+    [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kHideIcon];
+    [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kBaselineOffset];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kClockFormat];
 }
 
@@ -140,6 +148,7 @@
     
     // Now that everything else is set up, we file for notifications.
     // Some of the notification handlers rely on stuff we just set up.
+    _notificationTokens = [NSMutableArray new];
     [self fileNotifications];
 
     [_moCal bind:@"showWeeks" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:[@"values." stringByAppendingString:kShowWeeks] options:@{NSContinuouslyUpdatesValueBindingOption: @(YES)}];
@@ -1354,39 +1363,57 @@
 
 - (void)fileNotifications
 {
+    __weak typeof(self) weakSelf = self;
+    id token;
+
     // Day changed notification
-    [[NSNotificationCenter defaultCenter] addObserverForName:NSCalendarDayChangedNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-        [self resetCalendarToToday];
-        [self updateMenubarIcon];
-        [self updateTimer];
+    token = [[NSNotificationCenter defaultCenter] addObserverForName:NSCalendarDayChangedNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf resetCalendarToToday];
+        [strongSelf updateMenubarIcon];
+        [strongSelf updateTimer];
     }];
-    
+    [_notificationTokens addObject:token];
+
     // Timezone changed notification
-    [[NSNotificationCenter defaultCenter] addObserverForName:NSSystemTimeZoneDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-        [self updateMenubarIcon];
-        [self updateTimer];
-        [self->_ec refetchAll];
+    token = [[NSNotificationCenter defaultCenter] addObserverForName:NSSystemTimeZoneDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf updateMenubarIcon];
+        [strongSelf updateTimer];
+        [strongSelf->_ec refetchAll];
     }];
-    
+    [_notificationTokens addObject:token];
+
     // Locale notifications
-    [[NSNotificationCenter defaultCenter] addObserverForName:NSCurrentLocaleDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-        [self updateMenubarIcon];
-        [self updateTimer];
-        [self updateAgenda]; // 12/24 hr time change in sys prefs
+    token = [[NSNotificationCenter defaultCenter] addObserverForName:NSCurrentLocaleDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf updateMenubarIcon];
+        [strongSelf updateTimer];
+        [strongSelf updateAgenda]; // 12/24 hr time change in sys prefs
     }];
-    
+    [_notificationTokens addObject:token];
+
     // System clock notification
-    [[NSNotificationCenter defaultCenter] addObserverForName:NSSystemClockDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-        [self updateMenubarIcon];
-        [self updateTimer];
-        [self->_ec refetchAll];
+    token = [[NSNotificationCenter defaultCenter] addObserverForName:NSSystemClockDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf updateMenubarIcon];
+        [strongSelf updateTimer];
+        [strongSelf->_ec refetchAll];
     }];
+    [_notificationTokens addObject:token];
 
     // Wake from sleep notification
-    [[[NSWorkspace sharedWorkspace] notificationCenter] addObserverForName:NSWorkspaceDidWakeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
-        [self updateMenubarIcon];
-        [self updateTimer];
+    token = [[[NSWorkspace sharedWorkspace] notificationCenter] addObserverForName:NSWorkspaceDidWakeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf updateMenubarIcon];
+        [strongSelf updateTimer];
     }];
+    [_notificationTokens addObject:token];
 
     // Observe NSUserDefaults for preference changes
     for (NSString *keyPath in @[kShowEventDays, kMenuBarIconType, kShowMonthInIcon, kShowDayOfWeekInIcon, kShowDaysWithNoEventsInAgenda, kShowMeetingIndicator, kHideIcon, kBaselineOffset, kClockFormat]) {


### PR DESCRIPTION
Hey! I've been using Itsycal daily for a while and noticed a couple of things while poking around the code.

**Tooltip warning**: `MoCalToolTipWC` calls `showWindow:` which internally triggers `makeKeyAndOrderFront:` on a borderless window that can't become key. Switched to `orderFront:` to silence the warning.

**Missing KVO removals**: `fileNotifications` registers KVO observers for `kShowMeetingIndicator`, `kHideIcon`, and `kBaselineOffset`, but `dealloc` only removed 6 of the 9 registered key paths. Added the missing 3.

**Notification retain cycles**: The block-based `addObserverForName:` calls in `fileNotifications` captured `self` strongly, and the returned tokens were never stored - so `removeObserver:self` in dealloc couldn't actually remove them (that API only works for selector-based observers). Switched to weak-strong pattern and stored tokens for proper cleanup.

None of these cause practical issues since ViewController lives for the app's entire lifetime, but they're good hygiene and prevent surprises if the architecture ever changes.

Small, safe changes - two files, ~50 lines.