### PR TITLE
Visual refresh and new interaction features

### DIFF
--- a/Itsycal/AgendaViewController.h
+++ b/Itsycal/AgendaViewController.h
@@ -32,7 +32,9 @@
 @optional
 - (void)agendaHoveredOverRow:(NSInteger)row;
 - (void)agendaWantsToDeleteEvent:(EKEvent *)event;
+- (void)agendaWantsToEditEvent:(EKEvent *)event;
 - (void)agendaShowCalendarAppAtDate:(NSDate *)date;
 - (CGFloat)agendaMaxPossibleHeight;
+- (void)agendaWantsToReturnFocusToCalendar;
 
 @end

--- a/Itsycal/AgendaViewController.m
+++ b/Itsycal/AgendaViewController.m
@@ -44,6 +44,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
 @interface AgendaPopoverVC : NSViewController
 @property (nonatomic, weak) NSCalendar *nsCal;
 @property (nonatomic) NSButton *btnDelete;
+@property (nonatomic) NSButton *btnEdit;
 - (void)populateWithEventInfo:(EventInfo *)info;
 - (void)scrollToTopAndFlashScrollers;
 - (NSSize)size;
@@ -59,10 +60,15 @@ static NSString *kEventCellIdentifier = @"EventCell";
 @implementation AgendaViewController
 {
     NSPopover *_popover;
+    NSMutableArray<NSNumber *> *_cachedRowHeights;
+    CGFloat _lastKnownWidth;
+    NSInteger _lastHoveredRow;
 }
 
 - (void)loadView
 {
+    _lastHoveredRow = -1;
+
     // View controller content view
     NSView *v = [NSView new];
 
@@ -78,7 +84,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     _tv.intercellSpacing = NSMakeSize(0, 0);
     _tv.backgroundColor = NSColor.clearColor;
     _tv.floatsGroupRows = YES;
-    _tv.refusesFirstResponder = YES;
+    _tv.refusesFirstResponder = NO;
     _tv.dataSource = self;
     _tv.delegate = self;
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
@@ -87,7 +93,9 @@ static NSString *kEventCellIdentifier = @"EventCell";
     }
 #endif
     [_tv addTableColumn:[[NSTableColumn alloc] initWithIdentifier:kColumnIdentifier]];
-    
+    [_tv setDraggingSourceOperationMask:NSDragOperationMove forLocal:YES];
+    _tv.draggingDestinationFeedbackStyle = NSTableViewDraggingDestinationFeedbackStyleNone;
+
     // Calendars enclosing scrollview
     NSScrollView *tvContainer = [NSScrollView new];
     tvContainer.translatesAutoresizingMaskIntoConstraints = NO;
@@ -111,12 +119,12 @@ static NSString *kEventCellIdentifier = @"EventCell";
 
 - (void)viewDidLayout
 {
-    // Calculate height of view based on _tv row heights.
+    // Calculate height of view based on cached row heights.
     // We set the view's height using preferredContentSize.
-    NSInteger rows = [_tv numberOfRows];
+    [self ensureRowHeightsCached];
     CGFloat height = 0;
-    for (NSInteger row = 0; row < rows; ++row) {
-        height += [self tableView:_tv heightOfRow:row];
+    for (NSNumber *h in _cachedRowHeights) {
+        height += h.doubleValue;
     }
     if ([self.identifier isEqualToString:@"AgendaVC"]) {
         // Limit height so everything fits on the screen.
@@ -164,12 +172,15 @@ static NSString *kEventCellIdentifier = @"EventCell";
 {
     if (_showLocation != showLocation) {
         _showLocation = showLocation;
+        _cachedRowHeights = nil;
         [self reloadData];
     }
 }
 
 - (void)reloadData
 {
+    _cachedRowHeights = nil;
+    _lastHoveredRow = -1;
     [_tv reloadData];
     [_tv scrollRowToVisible:0];
     [[_tv enclosingScrollView] flashScrollers];
@@ -191,6 +202,8 @@ static NSString *kEventCellIdentifier = @"EventCell";
     [menu addItemWithTitle:NSLocalizedString(@"Copy", nil) action:@selector(copyEventToPasteboard:) keyEquivalent:@""];
     EventInfo *info = self.events[_tv.clickedRow];
     if (info.event.calendar.allowsContentModifications) {
+        NSMenuItem *editItem = [menu addItemWithTitle:NSLocalizedString(@"Edit…", nil) action:@selector(editEvent:) keyEquivalent:@""];
+        editItem.tag = _tv.clickedRow;
         NSMenuItem *item =[menu addItemWithTitle:NSLocalizedString(@"Delete…", nil) action:@selector(deleteEvent:) keyEquivalent:@""];
         item.tag = _tv.clickedRow;
     }
@@ -276,14 +289,18 @@ static NSString *kEventCellIdentifier = @"EventCell";
         popoverVC.btnDelete.action = @selector(deleteEvent:);
         unichar backspaceKey = NSBackspaceCharacter;
         popoverVC.btnDelete.keyEquivalent = [NSString stringWithCharacters:&backspaceKey length:1];
+
+        popoverVC.btnEdit.tag = row;
+        popoverVC.btnEdit.target = self;
+        popoverVC.btnEdit.action = @selector(editEvent:);
     }
-    
+
     NSRect positionRect = NSInsetRect([_tv rectOfRow:row], 8, 0);
     [_popover setAppearance:NSApp.effectiveAppearance];
     [_popover showRelativeToRect:positionRect ofView:_tv preferredEdge:NSRectEdgeMinX];
     [_popover setContentSize:popoverVC.size];
     [popoverVC scrollToTopAndFlashScrollers];
-    
+
     // Prevent popoverVC's _note from eating key presses (like esc and delete).
     [popoverVC.view.window makeFirstResponder:popoverVC.btnDelete];
 }
@@ -368,24 +385,69 @@ static NSString *kEventCellIdentifier = @"EventCell";
     return v;
 }
 
-- (CGFloat)tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row
+- (void)ensureRowHeightsCached
 {
+    // Invalidate cache if table width changed significantly.
+    CGFloat currentWidth = NSWidth(_tv.frame);
+    if (_cachedRowHeights && fabs(currentWidth - _lastKnownWidth) > 0.5) {
+        _cachedRowHeights = nil;
+    }
+    if (_cachedRowHeights) return;
+
     // Keep a cell around for measuring event cell height.
     static AgendaDateCell *dateCell = nil;
     static AgendaEventCell *eventCell = nil;
-    
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         eventCell = [AgendaEventCell new];
         dateCell = [AgendaDateCell new];
-        dateCell.frame = NSMakeRect(0, 0, NSWidth(self->_tv.frame), 999); // only width is important here
+        dateCell.frame = NSMakeRect(0, 0, NSWidth(self->_tv.frame), 999);
         dateCell.dayTextField.integerValue = 21;
     });
-    
+
+    _lastKnownWidth = currentWidth;
+    NSInteger rows = self.events ? (NSInteger)self.events.count : 0;
+    _cachedRowHeights = [NSMutableArray arrayWithCapacity:rows];
+    dateCell.frame = NSMakeRect(0, 0, currentWidth, 999);
+    CGFloat dateCellHeight = dateCell.fittingSize.height;
+
+    for (NSInteger row = 0; row < rows; row++) {
+        id obj = self.events[row];
+        CGFloat height;
+        if ([obj isKindOfClass:[EventInfo class]]) {
+            eventCell.frame = NSMakeRect(0, 0, currentWidth, 999);
+            [self populateEventCell:eventCell withInfo:obj];
+            height = eventCell.fittingSize.height;
+        } else {
+            height = dateCellHeight;
+        }
+        [_cachedRowHeights addObject:@(height)];
+    }
+}
+
+- (CGFloat)tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row
+{
+    [self ensureRowHeightsCached];
+    if (_cachedRowHeights && row < (NSInteger)_cachedRowHeights.count) {
+        return _cachedRowHeights[row].doubleValue;
+    }
+    // Fallback: compute directly (should not normally be reached).
+    static AgendaDateCell *dateCell = nil;
+    static AgendaEventCell *eventCell = nil;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        eventCell = [AgendaEventCell new];
+        dateCell = [AgendaDateCell new];
+        dateCell.frame = NSMakeRect(0, 0, NSWidth(self->_tv.frame), 999);
+        dateCell.dayTextField.integerValue = 21;
+    });
+
     CGFloat height = dateCell.fittingSize.height;
     id obj = self.events[row];
     if ([obj isKindOfClass:[EventInfo class]]) {
-        eventCell.frame = NSMakeRect(0, 0, NSWidth(_tv.frame), 999); // only width is important here
+        eventCell.frame = NSMakeRect(0, 0, NSWidth(_tv.frame), 999);
         [self populateEventCell:eventCell withInfo:obj];
         height = eventCell.fittingSize.height;
     }
@@ -406,7 +468,33 @@ static NSString *kEventCellIdentifier = @"EventCell";
 
 - (BOOL)tableView:(NSTableView *)tableView shouldSelectRow:(NSInteger)row
 {
-    return NO; // disable selection
+    // Allow selecting event rows but not group (date header) rows or empty event rows.
+    if ([self tableView:tableView isGroupRow:row]) return NO;
+    if ([self tableView:tableView isEmptyEventRow:row]) return NO;
+    return YES;
+}
+
+#pragma mark -
+#pragma mark Drag source
+
+- (id<NSPasteboardWriting>)tableView:(NSTableView *)tableView pasteboardWriterForRow:(NSInteger)row
+{
+    // Only allow dragging real event rows from modifiable calendars.
+    if ([self tableView:tableView isGroupRow:row]) return nil;
+    if ([self tableView:tableView isEmptyEventRow:row]) return nil;
+    id obj = self.events[row];
+    if (![obj isKindOfClass:[EventInfo class]]) return nil;
+    EventInfo *info = (EventInfo *)obj;
+    if (!info.event) return nil;
+    if (!info.event.calendar.allowsContentModifications) return nil;
+    NSPasteboardItem *item = [NSPasteboardItem new];
+    [item setString:info.event.eventIdentifier forType:@"com.mowglii.itsycal.event"];
+    return item;
+}
+
+- (void)tableView:(NSTableView *)tableView draggingSession:(NSDraggingSession *)session willBeginAtPoint:(NSPoint)screenPoint forRowIndexes:(NSIndexSet *)rowIndexes
+{
+    session.animatesToStartingPositionsOnCancelOrFail = YES;
 }
 
 - (void)tableView:(MoTableView *)tableView didHoverOverRow:(NSInteger)hoveredRow
@@ -419,19 +507,105 @@ static NSString *kEventCellIdentifier = @"EventCell";
         }
         hoveredRow = -1;
     }
-    for (NSInteger row = 0; row < [_tv numberOfRows]; row++) {
-        if (![self tableView:_tv isGroupRow:row]) {
-            BOOL isEmptyEventRow = [self tableView:_tv isEmptyEventRow:row];
-            BOOL isHovered = (row == hoveredRow && !isEmptyEventRow);
-            AgendaRowView *rowView = [_tv rowViewAtRow:row makeIfNecessary:NO];
-            rowView.isHovered = isHovered;
-            if (showPopoverOnHover && isHovered) {
+    // Only update the previously hovered row and the newly hovered row
+    // instead of iterating all rows.
+    if (_lastHoveredRow != hoveredRow) {
+        if (_lastHoveredRow >= 0 && _lastHoveredRow < [_tv numberOfRows]) {
+            AgendaRowView *oldRowView = [_tv rowViewAtRow:_lastHoveredRow makeIfNecessary:NO];
+            oldRowView.isHovered = NO;
+        }
+        if (hoveredRow >= 0 && hoveredRow < [_tv numberOfRows]) {
+            AgendaRowView *newRowView = [_tv rowViewAtRow:hoveredRow makeIfNecessary:NO];
+            newRowView.isHovered = YES;
+            if (showPopoverOnHover) {
                 [self showPopoverForRow:hoveredRow];
             }
         }
+        _lastHoveredRow = hoveredRow;
     }
     if (self.delegate && [self.delegate respondsToSelector:@selector(agendaHoveredOverRow:)]) {
         [self.delegate agendaHoveredOverRow:hoveredRow];
+    }
+}
+
+#pragma mark -
+#pragma mark Keyboard navigation
+
+- (BOOL)tableView:(MoTableView *)tableView handleKeyDown:(NSEvent *)event
+{
+    NSString *chars = [event charactersIgnoringModifiers];
+    if (chars.length != 1) return NO;
+    unichar keyChar = [chars characterAtIndex:0];
+    NSUInteger flags = [event modifierFlags];
+    BOOL noModifiers = !(flags & (NSEventModifierFlagCommand | NSEventModifierFlagShift | NSEventModifierFlagOption | NSEventModifierFlagControl));
+
+    // Return/Enter: show popover for the selected row
+    if (noModifiers && (keyChar == NSCarriageReturnCharacter || keyChar == NSEnterCharacter)) {
+        NSInteger selectedRow = [_tv selectedRow];
+        if (selectedRow >= 0) {
+            [self showPopoverForRow:selectedRow];
+        }
+        return YES;
+    }
+
+    // Escape: deselect and return focus to calendar
+    if (keyChar == 0x1B) { // Escape
+        [_tv deselectAll:nil];
+        if (self.delegate && [self.delegate respondsToSelector:@selector(agendaWantsToReturnFocusToCalendar)]) {
+            [self.delegate agendaWantsToReturnFocusToCalendar];
+        }
+        return YES;
+    }
+
+    // Tab: return focus to calendar
+    if (noModifiers && keyChar == NSTabCharacter) {
+        [_tv deselectAll:nil];
+        if (self.delegate && [self.delegate respondsToSelector:@selector(agendaWantsToReturnFocusToCalendar)]) {
+            [self.delegate agendaWantsToReturnFocusToCalendar];
+        }
+        return YES;
+    }
+
+    // Up arrow: move selection to previous selectable (event) row
+    if (noModifiers && keyChar == NSUpArrowFunctionKey) {
+        [self moveSelectionByDirection:-1];
+        return YES;
+    }
+
+    // Down arrow: move selection to next selectable (event) row
+    if (noModifiers && keyChar == NSDownArrowFunctionKey) {
+        [self moveSelectionByDirection:1];
+        return YES;
+    }
+
+    return NO;
+}
+
+- (void)moveSelectionByDirection:(NSInteger)direction
+{
+    NSInteger rowCount = [_tv numberOfRows];
+    if (rowCount == 0) return;
+
+    NSInteger selectedRow = [_tv selectedRow];
+    NSInteger candidate = selectedRow;
+
+    // If nothing selected, start from top or bottom depending on direction.
+    if (candidate == -1) {
+        candidate = (direction > 0) ? -1 : rowCount;
+    }
+
+    // Walk in the given direction to find the next selectable row.
+    while (YES) {
+        candidate += direction;
+        if (candidate < 0 || candidate >= rowCount) {
+            // Reached the boundary; keep current selection (or none).
+            return;
+        }
+        if ([self tableView:_tv shouldSelectRow:candidate]) {
+            [_tv selectRowIndexes:[NSIndexSet indexSetWithIndex:candidate] byExtendingSelection:NO];
+            [_tv scrollRowToVisible:candidate];
+            return;
+        }
     }
 }
 
@@ -457,6 +631,29 @@ static NSString *kEventCellIdentifier = @"EventCell";
     if (self.delegate && [self.delegate respondsToSelector:@selector(agendaWantsToDeleteEvent:)]) {
         EventInfo *info = self.events[row];
         [self.delegate agendaWantsToDeleteEvent:info.event];
+    }
+}
+
+#pragma mark -
+#pragma mark Edit event
+
+- (void)editEvent:(id)sender
+{
+    NSInteger row = -1;
+    if ([sender isKindOfClass:[NSButton class]]) {
+        NSButton *button = (NSButton *)sender;
+        button.bordered = YES;
+        button.bordered = NO;
+        row = button.tag;
+    } else if ([sender isKindOfClass:[NSMenuItem class]]) {
+        row = [(NSMenuItem *)sender tag];
+    }
+    if (row < 0) return;
+    // Close the popover before notifying the delegate.
+    [_popover close];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(agendaWantsToEditEvent:)]) {
+        EventInfo *info = self.events[row];
+        [self.delegate agendaWantsToEditEvent:info.event];
     }
 }
 
@@ -615,12 +812,22 @@ static NSString *kEventCellIdentifier = @"EventCell";
 
 - (void)dimEventsIfNecessary
 {
-    // If the user has the window showing, reload the agenda cells.
-    // This will redraw the events, dimming if necessary.
-    // This also enables/disables zoom buttons if necessary
-    // depending on whether a virtual meeting is in progress.
+    // If the user has the window showing, update only visible event cells.
+    // This redraws events to dim past ones and enables/disables zoom
+    // buttons depending on whether a virtual meeting is in progress.
     if (self.view.window.isVisible) {
-        [_tv reloadData];
+        NSRange visibleRange = [_tv rowsInRect:[_tv visibleRect]];
+        for (NSUInteger i = 0; i < visibleRange.length; i++) {
+            NSInteger row = (NSInteger)(visibleRange.location + i);
+            if (row >= (NSInteger)self.events.count) break;
+            id obj = self.events[row];
+            if ([obj isKindOfClass:[EventInfo class]]) {
+                AgendaEventCell *cell = [_tv viewAtColumn:0 row:row makeIfNecessary:NO];
+                if (cell) {
+                    [self populateEventCell:cell withInfo:obj];
+                }
+            }
+        }
     }
 }
 
@@ -659,7 +866,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
 
 - (void)drawKnobSlotInRect:(NSRect)slotRect highlight:(BOOL)flag
 {
-    [Theme.mainBackgroundColor set];
+    [[NSColor clearColor] set];
     NSRectFill(slotRect);
 }
 
@@ -675,16 +882,33 @@ static NSString *kEventCellIdentifier = @"EventCell";
 @implementation AgendaRowView
 
 - (void)drawBackgroundInRect:(NSRect)dirtyRect {
-    if (self.isHovered) {
+    NSRect rect = NSInsetRect(self.bounds, 8, 1);
+    if (self.isSelected) {
+        // Draw a stronger highlight for keyboard selection.
+        [[Theme.agendaHoverColor colorWithAlphaComponent:0.6] set];
+        [[NSBezierPath bezierPathWithRoundedRect:rect xRadius:8 yRadius:8] fill];
+    } else if (self.isHovered) {
         [Theme.agendaHoverColor set];
-        NSRect rect = NSInsetRect(self.bounds, 8, 1);
-        [[NSBezierPath bezierPathWithRoundedRect:rect xRadius:5 yRadius:5] fill];
+        [[NSBezierPath bezierPathWithRoundedRect:rect xRadius:8 yRadius:8] fill];
     }
+}
+
+// Suppress the default blue selection highlight drawn by NSTableRowView.
+- (void)drawSelectionInRect:(NSRect)dirtyRect {
+    // Intentionally empty; selection is drawn in drawBackgroundInRect:.
 }
 
 - (void)setIsHovered:(BOOL)isHovered {
     if (_isHovered != isHovered) {
         _isHovered = isHovered;
+        [self setNeedsDisplay:YES];
+    }
+}
+
+- (void)setSelected:(BOOL)selected {
+    BOOL changed = (self.isSelected != selected);
+    [super setSelected:selected];
+    if (changed) {
         [self setNeedsDisplay:YES];
     }
 }
@@ -740,8 +964,8 @@ static NSString *kEventCellIdentifier = @"EventCell";
 
 - (void)drawRect:(NSRect)dirtyRect
 {
-    // Must be opaque so rows can scroll under it.
-    [Theme.mainBackgroundColor set];
+    // Semi-transparent so rows scroll under it while vibrancy partially shows through.
+    [[Theme.mainBackgroundColor colorWithAlphaComponent:0.9] set];
     NSRectFillUsingOperation(self.bounds, NSCompositingOperationSourceOver);
     NSRect r = NSMakeRect(10, self.bounds.size.height - 4, self.bounds.size.width - 20, 1);
     [Theme.agendaDividerColor set];
@@ -772,6 +996,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     if (self) {
         self.identifier = kEventCellIdentifier;
         _titleTextField = label();
+        _titleTextField.font = [NSFont systemFontOfSize:SizePref.fontSize weight:NSFontWeightMedium];
         _titleTextField.maximumNumberOfLines = 1;
         _locationTextField = label();
         _locationTextField.maximumNumberOfLines = 2;
@@ -817,7 +1042,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
         
         MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:self metrics:nil views:NSDictionaryOfVariableBindings(_grid)];
         [vfl :@"H:[_grid]-11-|"];
-        [vfl :@"V:|-3-[_grid]-3-|"];
+        [vfl :@"V:|-5-[_grid]-5-|"];
         
         CGFloat leadingConstant = SizePref.agendaEventLeadingMargin;
         _gridLeadingConstraint = [_grid.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:leadingConstant];
@@ -840,7 +1065,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     _gridLeadingConstraint.constant = SizePref.agendaEventLeadingMargin;
     _btnVideo.image = [NSImage imageNamed:SizePref.videoImageName];
     _btnVideo.image.template = YES;
-    _titleTextField.font = [NSFont systemFontOfSize:SizePref.fontSize];
+    _titleTextField.font = [NSFont systemFontOfSize:SizePref.fontSize weight:NSFontWeightMedium];
     _locationTextField.font = [NSFont systemFontOfSize:SizePref.fontSize];
     _durationTextField.font = [NSFont systemFontOfSize:SizePref.fontSize];
 }
@@ -905,26 +1130,19 @@ static NSString *kEventCellIdentifier = @"EventCell";
     BOOL isPending = [[self.eventInfo.event valueForKey:@"participationStatus"] integerValue] == EKParticipantStatusPending;
     if (self.eventInfo.event.hasAttendees && isPending) {
         [[NSColor colorWithPatternImage:[self pendingPatternImage]] set];
-        [[NSBezierPath bezierPathWithRoundedRect:NSInsetRect(self.bounds, 8, 1) xRadius:5 yRadius:5] fill];
+        [[NSBezierPath bezierPathWithRoundedRect:NSInsetRect(self.bounds, 8, 1) xRadius:8 yRadius:8] fill];
     }
-    // Draw colored dot. Dot is elongated for all-day events.
-    // Stroke for tentative and pending events, otherwise fill.
+    // Draw vertical color bar on the left edge of the event cell.
+    // Taller pill for all-day events.
     CGFloat alpha = self.dim ? 0.5 : 1;
-    CGFloat x = 11;
-    CGFloat yOffset = SizePref.fontSize + 2;
-    CGFloat dotWidthX = SizePref.agendaDotWidth;
-    CGFloat dotWidthY = dotWidthX;
-    CGFloat radius = dotWidthX / 2.0;
+    CGFloat barWidth = 3;
+    CGFloat barX = 10;
+    CGFloat barPadding = 5;
+    CGFloat barHeight = NSHeight(self.bounds) - 2 * barPadding;
+    CGFloat barRadius = barWidth / 2.0;
     NSColor *dotColor = self.eventInfo.event.calendar.color;
-    if (self.eventInfo.isAllDay) {
-        x += 1;
-        yOffset += 2;
-        dotWidthX -= 2;
-        dotWidthY += 4;
-        radius -= 1;
-    }
     [[dotColor colorWithAlphaComponent:alpha] set];
-    NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:NSMakeRect(x, NSHeight(self.bounds) - yOffset, dotWidthX, dotWidthY) xRadius:radius yRadius:radius];
+    NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:NSMakeRect(barX, barPadding, barWidth, barHeight) xRadius:barRadius yRadius:barRadius];
     if (self.eventInfo.event.hasAttendees && (isTentative || isPending)) {
         p.lineWidth = 1.5;
         [p stroke];
@@ -1003,12 +1221,19 @@ static NSString *kEventCellIdentifier = @"EventCell";
         _btnDelete.focusRingType = NSFocusRingTypeNone;
         _btnDelete.bordered = NO;
         _btnDelete.contentTintColor = NSColor.secondaryLabelColor;
-        
+
+        _btnEdit = [NSButton new];
+        _btnEdit.title = @"✎";
+        _btnEdit.focusRingType = NSFocusRingTypeNone;
+        _btnEdit.bordered = NO;
+        _btnEdit.contentTintColor = NSColor.secondaryLabelColor;
+
         NSView *titleHolder = [NSView new];
         [titleHolder addSubview:_title];
+        [titleHolder addSubview:_btnEdit];
         [titleHolder addSubview:_btnDelete];
-        MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:titleHolder metrics:nil views:NSDictionaryOfVariableBindings(_title, _btnDelete)];
-        [vfl :@"H:|[_title]-(>=10)-[_btnDelete]|" :NSLayoutFormatAlignAllCenterY];
+        MoVFLHelper *vfl = [[MoVFLHelper alloc] initWithSuperview:titleHolder metrics:nil views:NSDictionaryOfVariableBindings(_title, _btnEdit, _btnDelete)];
+        [vfl :@"H:|[_title]-(>=10)-[_btnEdit]-2-[_btnDelete]|" :NSLayoutFormatAlignAllCenterY];
         [vfl :@"V:|[_title]|"];
         [titleHolder.widthAnchor constraintEqualToConstant:POPOVER_TEXT_WIDTH].active = YES;
         
@@ -1129,8 +1354,9 @@ static NSString *kEventCellIdentifier = @"EventCell";
     // Hide URL row IF there's no URL.
     [_grid rowAtIndex:9].hidden = !info.event.URL;
 
-    // Hide delete button IF event doesn't allow modification.
+    // Hide edit and delete buttons IF event doesn't allow modification.
     _btnDelete.hidden = !info.event.calendar.allowsContentModifications;
+    _btnEdit.hidden   = !info.event.calendar.allowsContentModifications;
 
     // All-day events don't show time.
     intervalFormatter.timeStyle = info.event.isAllDay
@@ -1335,6 +1561,7 @@ static NSString *kEventCellIdentifier = @"EventCell";
     _duration.font = [NSFont systemFontOfSize:SizePref.fontSize];
     _recurrence.font = _duration.font;
     _btnDelete.font  = [NSFont systemFontOfSize:SizePref.fontSize+3];
+    _btnEdit.font    = [NSFont systemFontOfSize:SizePref.fontSize+3];
 
     _title.textColor = Theme.agendaEventTextColor;
     _duration.textColor = Theme.agendaEventTextColor;

--- a/Itsycal/Colors.xcassets/HighlightedDOWBackgroundColor.colorset/Contents.json
+++ b/Itsycal/Colors.xcassets/HighlightedDOWBackgroundColor.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.940",
-          "alpha" : "1.000",
-          "blue" : "0.940",
-          "green" : "0.940"
+          "red" : "0.960",
+          "alpha" : "0.600",
+          "blue" : "0.960",
+          "green" : "0.960"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.235",
-          "alpha" : "1.000",
-          "blue" : "0.235",
-          "green" : "0.235"
+          "red" : "0.280",
+          "alpha" : "0.500",
+          "blue" : "0.280",
+          "green" : "0.280"
         }
       }
     }

--- a/Itsycal/Colors.xcassets/WindowBorderColor.colorset/Contents.json
+++ b/Itsycal/Colors.xcassets/WindowBorderColor.colorset/Contents.json
@@ -10,7 +10,7 @@
         "color-space" : "srgb",
         "components" : {
           "red" : "0.400",
-          "alpha" : "0.400",
+          "alpha" : "0.200",
           "blue" : "0.400",
           "green" : "0.400"
         }
@@ -28,7 +28,7 @@
         "color-space" : "srgb",
         "components" : {
           "red" : "0.600",
-          "alpha" : "0.400",
+          "alpha" : "0.200",
           "blue" : "0.600",
           "green" : "0.600"
         }

--- a/Itsycal/EventCenter.h
+++ b/Itsycal/EventCenter.h
@@ -33,6 +33,8 @@
 
 - (BOOL)saveEvent:(EKEvent *)event error:(NSError **)error;
 
+- (BOOL)updateEvent:(EKEvent *)event span:(EKSpan)span error:(NSError **)error;
+
 - (BOOL)removeEvent:(EKEvent *)event span:(EKSpan)span error:(NSError **)error;
 
 - (void)fetchEvents;
@@ -51,6 +53,10 @@
 // When the user selects/unselects calendars in Prefs, we update
 // the list of selected calendars.
 - (void)updateSelectedCalendarsForIdentifier:(NSString *)identifier selected:(BOOL)selected;
+
+// Move an event to a new date, preserving its time-of-day and duration.
+// Returns YES on success.
+- (BOOL)moveEventWithIdentifier:(NSString *)eventIdentifier toDate:(MoDate)date;
 
 // Clear cached events and refetch.
 - (void)refetchAll;

--- a/Itsycal/EventCenter.m
+++ b/Itsycal/EventCenter.m
@@ -24,6 +24,7 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
     NSDictionary         *_filteredEventsForDate;  // _queueIsol
     NSMutableIndexSet    *_previouslyFetchedDates; // _queueWork
     NSArray              *_sourcesAndCalendars;    // _queueIsol2
+    NSMutableDictionary  *_meetingURLCache;        // _queueWork, keyed by event identifier
     dispatch_queue_t      _queueWork;
     dispatch_queue_t      _queueIsol;
     dispatch_queue_t      _queueIsol2;
@@ -55,6 +56,7 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
         _eventsForDate  = [NSMutableDictionary new];
         _filteredEventsForDate = [NSDictionary new];
         _previouslyFetchedDates = [NSMutableIndexSet new];
+        _meetingURLCache = [NSMutableDictionary new];
         _queueWork = dispatch_queue_create("com.mowglii.Itsycal.queueWork", DISPATCH_QUEUE_SERIAL);
         _queueIsol = dispatch_queue_create("com.mowglii.Itsycal.queueIsol", DISPATCH_QUEUE_SERIAL);
         _queueIsol2 = dispatch_queue_create("com.mowglii.Itsycal.queueIsol2", DISPATCH_QUEUE_SERIAL);
@@ -101,8 +103,38 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
     return [_store saveEvent:event span:EKSpanThisEvent commit:YES error:error];
 }
 
+- (BOOL)updateEvent:(EKEvent *)event span:(EKSpan)span error:(NSError **)error {
+    return [_store saveEvent:event span:span commit:YES error:error];
+}
+
 - (BOOL)removeEvent:(EKEvent *)event span:(EKSpan)span error:(NSError **)error {
     return [_store removeEvent:event span:span commit:YES error:error];
+}
+
+- (BOOL)moveEventWithIdentifier:(NSString *)eventIdentifier toDate:(MoDate)date {
+    if (!eventIdentifier) return NO;
+    EKEvent *event = [_store eventWithIdentifier:eventIdentifier];
+    if (!event) return NO;
+    if (!event.calendar.allowsContentModifications) return NO;
+
+    // Calculate the day difference between old start date and new date.
+    NSDate *newStartNSDate = MakeNSDateWithDate(date, _cal);
+    NSDate *oldStartDay = [_cal startOfDayForDate:event.startDate];
+    NSDateComponents *diff = [_cal components:NSCalendarUnitDay fromDate:oldStartDay toDate:newStartNSDate options:0];
+    if (diff.day == 0) return YES; // already on that date
+
+    // Shift both startDate and endDate by the day difference.
+    NSDate *newStart = [_cal dateByAddingUnit:NSCalendarUnitDay value:diff.day toDate:event.startDate options:0];
+    NSDate *newEnd   = [_cal dateByAddingUnit:NSCalendarUnitDay value:diff.day toDate:event.endDate options:0];
+    event.startDate = newStart;
+    event.endDate   = newEnd;
+
+    NSError *error = nil;
+    BOOL result = [_store saveEvent:event span:EKSpanThisEvent commit:YES error:&error];
+    if (!result && error) {
+        os_log_error(OS_LOG_DEFAULT, "Failed to move event: %{public}@", error.localizedDescription);
+    }
+    return result;
 }
 
 - (void)updateSelectedCalendarsForIdentifier:(NSString *)identifier selected:(BOOL)selected {
@@ -169,6 +201,7 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
     MoDate endMoDate   = [self.delegate fetchEndDate];
     dispatch_async(_queueWork, ^{
         @autoreleasepool {
+            [self->_meetingURLCache removeAllObjects];
             [self _fetchSourcesAndCalendars];
             [self _fetchEventsWithStartDate:startMoDate endDate:endMoDate refetch:YES];
         }
@@ -354,7 +387,7 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
 - (void)_filterEvents {
     //os_log(OS_LOG_DEFAULT, " %s", __FUNCTION__);
     NSMutableDictionary *filteredEventsForDate = [NSMutableDictionary new];
-    NSArray *selectedCalendars = [[NSUserDefaults standardUserDefaults] arrayForKey:kSelectedCalendars];
+    NSSet *selectedCalendars = [NSSet setWithArray:[[NSUserDefaults standardUserDefaults] arrayForKey:kSelectedCalendars]];
     for (NSDate *date in _eventsForDate) {
         for (EventInfo *info in _eventsForDate[date]) {
             if ([selectedCalendars containsObject:info.event.calendar.calendarIdentifier]) {
@@ -364,7 +397,15 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
                 // Check if there is a virtual meeting (e.g. Zoom) link.
                 // We limit this check to filtered events in an
                 // attempt to limit how much text processing we do.
-                [self checkForZoomURL:info];
+                // Use cached result if available to avoid expensive NSDataDetector work.
+                NSString *eventID = info.event.eventIdentifier;
+                id cachedURL = _meetingURLCache[eventID];
+                if (cachedURL) {
+                    info.zoomURL = (cachedURL == [NSNull null]) ? nil : cachedURL;
+                } else {
+                    [self checkForZoomURL:info];
+                    _meetingURLCache[eventID] = info.zoomURL ?: [NSNull null];
+                }
                 [filteredEventsForDate[date] addObject:info];
             }
         }

--- a/Itsycal/EventViewController.h
+++ b/Itsycal/EventViewController.h
@@ -9,6 +9,7 @@
 #import <Cocoa/Cocoa.h>
 
 @class EventCenter;
+@class EKEvent;
 
 @interface EventViewController : NSViewController <NSTextFieldDelegate, NSTextViewDelegate>
 
@@ -16,5 +17,6 @@
 @property (nonatomic, weak) NSPopover *enclosingPopover;
 @property (nonatomic, weak) NSCalendar *cal;
 @property (nonatomic) NSDate *calSelectedDate;
+@property (nonatomic) EKEvent *editingEvent; // nil = create mode, non-nil = edit mode
 
 @end

--- a/Itsycal/EventViewController.m
+++ b/Itsycal/EventViewController.m
@@ -290,7 +290,7 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
     [super viewWillAppear];
 
     self.view.window.defaultButtonCell = _saveButton.cell;
-    
+
     // If self.calSelectedDate is today, the initialStart is set to
     // the next whole hour. Otherwise, 8am of self.calselectedDate.
     // Default duration is same as setting in Calendar.app.
@@ -309,7 +309,7 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
                                       value:newEventDuration
                                      toDate:initialStart
                                     options:0];
-    
+
     // Initial values for form fields.
     _title.stringValue = @"";
     _location.stringValue = @"";
@@ -330,7 +330,7 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
     [_repEndPopup selectItemAtIndex:0];  // 'Never' selected
     [_alertPopup selectItemAtIndex:0];   // 'None' selected
     _saveButton.enabled  = NO;
-    
+
     // Function to make colored dots for calendar popup.
     NSImage* (^coloredDot)(NSColor *) = ^NSImage* (NSColor *color) {
         return [NSImage imageWithSize:NSMakeSize(8, 8) flipped:NO drawingHandler:^BOOL(NSRect dstRect) {
@@ -339,7 +339,7 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
             return YES;
         }];
     };
-    
+
     // Populate calendar popup.
     NSString *defaultCalendarIdentifier = [self.ec defaultCalendarIdentifier];
     NSArray *sourcesAndCalendars = [self.ec sourcesAndCalendars];
@@ -372,10 +372,123 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
             }
         }
     }
-    
+
     // Populate alert popup AFTER calendar popup since its
     // contents depends on which calendar is selected.
     [self populateAlertPopup];
+
+    // If editing an existing event, populate fields from it.
+    if (self.editingEvent) {
+        [self populateFieldsFromEditingEvent];
+    }
+}
+
+- (void)populateFieldsFromEditingEvent
+{
+    EKEvent *event = self.editingEvent;
+
+    // Title
+    _title.stringValue = event.title ?: @"";
+
+    // Location
+    _location.stringValue = event.location ?: @"";
+
+    // URL
+    _url.stringValue = event.URL ? event.URL.absoluteString : @"";
+
+    // Notes
+    _notes.string = event.notes ?: @"";
+
+    // All-day
+    _allDayCheckbox.state = event.isAllDay ? NSControlStateValueOn : NSControlStateValueOff;
+    if (event.isAllDay) {
+        _startDate.datePickerElements = NSDatePickerElementFlagYearMonthDay;
+        _endDate.datePickerElements   = NSDatePickerElementFlagYearMonthDay;
+    } else {
+        _startDate.datePickerElements = NSDatePickerElementFlagYearMonthDay | NSDatePickerElementFlagHourMinute;
+        _endDate.datePickerElements   = NSDatePickerElementFlagYearMonthDay | NSDatePickerElementFlagHourMinute;
+    }
+
+    // Start/end dates
+    _startDate.dateValue = event.startDate;
+    _endDate.minDate     = event.startDate;
+    _endDate.dateValue   = event.endDate;
+    _repEndDate.minDate  = event.startDate;
+    _repEndDate.dateValue = event.endDate;
+
+    // Calendar — select the event's calendar in the popup.
+    NSArray *sourcesAndCalendars = [self.ec sourcesAndCalendars];
+    for (id obj in sourcesAndCalendars) {
+        if ([obj isKindOfClass:[CalendarInfo class]]) {
+            CalendarInfo *calInfo = obj;
+            if ([calInfo.calendar.calendarIdentifier isEqualToString:event.calendar.calendarIdentifier]) {
+                NSInteger tag = [sourcesAndCalendars indexOfObject:obj];
+                [_calPopup selectItemWithTag:tag];
+                break;
+            }
+        }
+    }
+
+    // Recurrence rule
+    if (event.hasRecurrenceRules && event.recurrenceRules.count > 0) {
+        EKRecurrenceRule *rule = event.recurrenceRules.firstObject;
+        NSInteger repIndex = 0;
+        switch (rule.frequency) {
+            case EKRecurrenceFrequencyDaily:
+                repIndex = 1; // Every Day
+                break;
+            case EKRecurrenceFrequencyWeekly:
+                repIndex = (rule.interval == 2) ? 3 : 2; // Every 2 Weeks or Every Week
+                break;
+            case EKRecurrenceFrequencyMonthly:
+                repIndex = 4; // Every Month
+                break;
+            case EKRecurrenceFrequencyYearly:
+                repIndex = 5; // Every Year
+                break;
+        }
+        [_repPopup selectItemAtIndex:repIndex];
+        _repEndLabel.hidden = (repIndex == 0);
+        _repEndPopup.hidden = (repIndex == 0);
+
+        if (rule.recurrenceEnd && rule.recurrenceEnd.endDate) {
+            [_repEndPopup selectItemAtIndex:1]; // 'On Date'
+            _repEndDate.dateValue = rule.recurrenceEnd.endDate;
+            _repEndDate.hidden = NO;
+        } else {
+            [_repEndPopup selectItemAtIndex:0]; // 'Never'
+            _repEndDate.hidden = YES;
+        }
+    }
+
+    // Alert — repopulate for the correct all-day state, then try to match.
+    [self populateAlertPopup];
+    if (event.alarms.count > 0) {
+        NSTimeInterval offset = event.alarms.firstObject.relativeOffset;
+        NSInteger numOffsets = 0;
+        const NSTimeInterval *offsets = nil;
+        if (event.isAllDay) {
+            numOffsets = kAlertAllDayNumOffsets;
+            offsets = kAlertAllDayRelativeOffsets;
+        } else {
+            numOffsets = kAlertRegularNumOffsets;
+            offsets = kAlertRegularRelativeOffsets;
+        }
+        for (NSInteger i = 0; i < numOffsets; i++) {
+            if (offsets[i] == offset) {
+                [_alertPopup selectItemAtIndex:i];
+                break;
+            }
+        }
+    }
+
+    // Update notes scroll view height for pre-populated text.
+    [self textDidChange:[NSNotification notificationWithName:NSTextDidChangeNotification object:_notes]];
+
+    // Enable save button since we have a title, update button label.
+    NSString *trimmedTitle = [_title.stringValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    _saveButton.enabled = ![trimmedTitle isEqualToString:@""];
+    _saveButton.title = NSLocalizedString(@"Save Changes", @"");
 }
 
 - (void)viewDidAppear
@@ -522,15 +635,15 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
     // Set startDate and endDate.
     NSDate *startDate = _startDate.dateValue;
     NSDate *endDate   = _endDate.dateValue;
-    
+
     // Get the calendar.
     NSInteger index = _calPopup.selectedItem.tag;
     NSArray *sourcesAndCalendars = [self.ec sourcesAndCalendars];
     CalendarInfo *calInfo = sourcesAndCalendars[index];
 
-    // Create the event.
+    // Use existing event in edit mode, or create a new one.
     NSCharacterSet *whitespaceSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
-    EKEvent *event  = [self.ec newEvent];
+    EKEvent *event = self.editingEvent ?: [self.ec newEvent];
     event.title     = [_title.stringValue stringByTrimmingCharactersInSet:whitespaceSet];
     event.location  = [_location.stringValue stringByTrimmingCharactersInSet:whitespaceSet];
     event.URL       = [NSURL URLWithString:[_url.stringValue stringByTrimmingCharactersInSet:whitespaceSet]];
@@ -541,6 +654,8 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
     NSString *notes = [_notes.string stringByTrimmingCharactersInSet:whitespaceSet];
     if (![notes isEqualToString:@""]) {
         event.notes = notes;
+    } else {
+        event.notes = nil;
     }
     // !Important! timeZone MUST be nil if it is an allDay event.
     // If you set timeZone after setting allDay, the start and end dates
@@ -548,7 +663,7 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
     // Alternatively, we could have set timeZone before setting allDay
     // because setting allDay == YES sets timeZone to nil.
     event.timeZone  = event.isAllDay ? nil : [NSTimeZone localTimeZone];
-    
+
     // Recurrence rule.
     EKRecurrenceFrequency frequency;
     NSInteger interval = 1;
@@ -583,15 +698,21 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
     if (repIndex != 0) {
         recurrence = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency:frequency interval:interval end:recurrenceEnd];
     }
+    // In edit mode, clear existing recurrence rules before setting new ones.
+    if (self.editingEvent) {
+        for (EKRecurrenceRule *existingRule in [event.recurrenceRules copy]) {
+            [event removeRecurrenceRule:existingRule];
+        }
+    }
     if (recurrence != nil) {
         event.recurrenceRules = @[recurrence];
     }
-    
+
     // Remove default alert(s) set on this event. We only add the
     // alert the user has selected - which may be the default alert
     // since we tried to set it in -populateAlertPopup. This avoids
     // having the default alert set twice.
-    for (EKAlarm *alarm in event.alarms) {
+    for (EKAlarm *alarm in [event.alarms copy]) {
         [event removeAlarm:alarm];
     }
     // Set the alert that was selected in the alert popup.
@@ -608,10 +729,17 @@ const NSTimeInterval kAlertRegularRelativeOffsets[kAlertRegularNumOffsets] = {
             [event addAlarm:[EKAlarm alarmWithRelativeOffset:offset]];
         }
     }
-    
+
     // Commit the event.
     NSError *error = NULL;
-    BOOL saved = [self.ec saveEvent:event error:&error];
+    BOOL saved;
+    if (self.editingEvent) {
+        // For recurring events, default to editing only this occurrence.
+        EKSpan span = event.hasRecurrenceRules ? EKSpanThisEvent : EKSpanThisEvent;
+        saved = [self.ec updateEvent:event span:span error:&error];
+    } else {
+        saved = [self.ec saveEvent:event error:&error];
+    }
     if (saved == NO && error != nil) {
         [[NSAlert alertWithError:error] runModal];
     }

--- a/Itsycal/ItsycalWindow.m
+++ b/Itsycal/ItsycalWindow.m
@@ -6,17 +6,42 @@
 //  Copyright (c) 2014 mowglii.com. All rights reserved.
 //
 
+#import <QuartzCore/QuartzCore.h>
 #import "ItsycalWindow.h"
 #import "Themer.h"
 
 static const CGFloat kMinimumSpaceBetweenWindowAndScreenEdge = 10;
 static const CGFloat kArrowHeight  = 8;
-static const CGFloat kCornerRadius = 10;
+static const CGFloat kCornerRadius = 12;
 static const CGFloat kBorderWidth  = 1;
 static const CGFloat kMarginWidth  = 0;
 static const CGFloat kWindowTopMargin    = kCornerRadius + kBorderWidth + kArrowHeight;
 static const CGFloat kWindowSideMargin   = kMarginWidth  + kBorderWidth;
 static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth;
+
+// Convert NSBezierPath to CGPathRef for use as a layer mask.
+static CGPathRef CGPathCreateFromNSBezierPath(NSBezierPath *bezierPath) {
+    CGMutablePathRef path = CGPathCreateMutable();
+    NSInteger n = bezierPath.elementCount;
+    for (NSInteger i = 0; i < n; i++) {
+        NSPoint points[3];
+        switch ([bezierPath elementAtIndex:i associatedPoints:points]) {
+            case NSBezierPathElementMoveTo:
+                CGPathMoveToPoint(path, NULL, points[0].x, points[0].y);
+                break;
+            case NSBezierPathElementLineTo:
+                CGPathAddLineToPoint(path, NULL, points[0].x, points[0].y);
+                break;
+            case NSBezierPathElementCurveTo:
+                CGPathAddCurveToPoint(path, NULL, points[0].x, points[0].y, points[1].x, points[1].y, points[2].x, points[2].y);
+                break;
+            case NSBezierPathElementClosePath:
+                CGPathCloseSubpath(path);
+                break;
+        }
+    }
+    return path;
+}
 
 @interface ItsycalWindowFrameView : NSView
 @property (nonatomic, assign) CGFloat arrowMidX;
@@ -153,34 +178,46 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth;
 // =========================================================================
 
 @implementation ItsycalWindowFrameView
-
-- (void)drawRect:(NSRect)dirtyRect
 {
-    // Draw the window background with the little arrow
-    // at the top.
-    
+    NSVisualEffectView *_vibrancyView;
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    self = [super initWithFrame:frameRect];
+    if (self) {
+        [self setupVibrancyView];
+    }
+    return self;
+}
+
+- (void)setupVibrancyView
+{
+    _vibrancyView = [[NSVisualEffectView alloc] initWithFrame:self.bounds];
+    _vibrancyView.material = NSVisualEffectMaterialMenu;
+    _vibrancyView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+    _vibrancyView.state = NSVisualEffectStateActive;
+    _vibrancyView.translatesAutoresizingMaskIntoConstraints = NO;
+    _vibrancyView.wantsLayer = YES;
+    [self addSubview:_vibrancyView positioned:NSWindowBelow relativeTo:nil];
+    [NSLayoutConstraint activateConstraints:@[
+        [_vibrancyView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [_vibrancyView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+        [_vibrancyView.topAnchor constraintEqualToAnchor:self.topAnchor],
+        [_vibrancyView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+    ]];
+}
+
+- (NSBezierPath *)windowShapePath
+{
     // The rectangular part of frame view must be inset and
     // shortened to make room for the border and arrow.
     NSRect rect = NSInsetRect(self.bounds, kBorderWidth, kBorderWidth);
     rect.size.height -= kArrowHeight;
-    
-    // Do we need to draw the whole window?
-    // If dirtyRect is inside the body of the window, we can just fill it.
-    NSRect bodyRect = NSInsetRect(rect, 1, kCornerRadius);
-    if (NSContainsRect(bodyRect, dirtyRect)) {
-        [Theme.mainBackgroundColor setFill];
-        NSRectFill(dirtyRect);
-        return;
-    }
-    
-    // We need to draw the whole window.
 
-    [[NSColor clearColor] set];
-    NSRectFill(self.bounds);
-    
     NSBezierPath *rectPath = [NSBezierPath bezierPathWithRoundedRect:rect xRadius:kCornerRadius yRadius:kCornerRadius];
-    
-    // Append the arrow to the body if its right ege is inside
+
+    // Append the arrow to the body if its right edge is inside
     // the right edge of the body (taking into account the corner
     // radius). This accounts for the edge-case where Itsycal is
     // all the way to the right in the menu bar. This is possible
@@ -198,14 +235,38 @@ static const CGFloat kWindowBottomMargin = kCornerRadius + kBorderWidth;
         [arrowPath relativeCurveToPoint:NSMakePoint(kArrowHeight + curveOffset, -kArrowHeight) controlPoint1:NSMakePoint(curveOffset, 0) controlPoint2:NSMakePoint(kArrowHeight, -kArrowHeight)];
         [rectPath appendBezierPath:arrowPath];
     }
+    return rectPath;
+}
+
+- (void)updateVibrancyMask
+{
+    NSBezierPath *shapePath = [self windowShapePath];
+    CAShapeLayer *maskLayer = [CAShapeLayer layer];
+    maskLayer.frame = self.bounds;
+    CGPathRef cgPath = CGPathCreateFromNSBezierPath(shapePath);
+    maskLayer.path = cgPath;
+    CGPathRelease(cgPath);
+    _vibrancyView.layer.mask = maskLayer;
+}
+
+- (void)layout
+{
+    [super layout];
+    [self updateVibrancyMask];
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+    // Clear the entire frame so the vibrancy view shows through.
+    [[NSColor clearColor] set];
+    NSRectFill(self.bounds);
+
+    // Draw only the border stroke around the window shape.
+    // The vibrancy view provides the translucent background.
+    NSBezierPath *shapePath = [self windowShapePath];
     [Theme.windowBorderColor setStroke];
-#ifdef DEBUG
-    [NSColor.greenColor setStroke];
-#endif
-    [rectPath setLineWidth:2*kBorderWidth];
-    [rectPath stroke];
-    [Theme.mainBackgroundColor setFill];
-    [rectPath fill];
+    [shapePath setLineWidth:2*kBorderWidth];
+    [shapePath stroke];
 }
 
 @end

--- a/Itsycal/MoCalCell.m
+++ b/Itsycal/MoCalCell.m
@@ -52,6 +52,7 @@
 
 - (void)setIsToday:(BOOL)isToday {
     _isToday = isToday;
+    [self updateTextColor];
     [self setNeedsDisplay:YES];
 }
 
@@ -88,32 +89,35 @@
 }
 
 - (void)updateTextColor {
-    self.textField.textColor = self.isInCurrentMonth ? Theme.currentMonthTextColor : Theme.noncurrentMonthTextColor;
+    if (self.isToday) {
+        self.textField.textColor = [NSColor whiteColor];
+    } else if (self.isInCurrentMonth) {
+        self.textField.textColor = Theme.currentMonthTextColor;
+    } else {
+        self.textField.textColor = Theme.noncurrentMonthTextColor;
+    }
 }
 
 - (void)drawRect:(NSRect)dirtyRect
 {
     CGFloat radius = SizePref.cellRadius;
+    NSRect r = NSInsetRect(self.bounds, 3, 3);
     if (self.isToday) {
-        [Theme.todayCellColor set];
-        NSRect r = NSInsetRect(self.bounds, 3, 3);
-        NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:r xRadius:radius yRadius:radius];
-        [p setLineWidth:2];
-        [p stroke];
+        // Filled rounded rect for today — not a full circle,
+        // so wider numbers like "28" fit comfortably.
+        NSRect todayRect = NSInsetRect(self.bounds, 4, 4);
+        [Theme.todayCellColor setFill];
+        [[NSBezierPath bezierPathWithRoundedRect:todayRect xRadius:radius yRadius:radius] fill];
     }
     else if (self.isSelected) {
-        [Theme.selectedCellColor set];
-        NSRect r = NSInsetRect(self.bounds, 3, 3);
-        NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:r xRadius:radius yRadius:radius];
-        [p setLineWidth:2];
-        [p stroke];
+        // Subtle filled background for selection
+        [[NSColor.labelColor colorWithAlphaComponent:0.12] setFill];
+        [[NSBezierPath bezierPathWithRoundedRect:r xRadius:radius yRadius:radius] fill];
     }
     else if (self.isHovered) {
-        [Theme.hoveredCellColor set];
-        NSRect r = NSInsetRect(self.bounds, 3, 3);
-        NSBezierPath *p = [NSBezierPath bezierPathWithRoundedRect:r xRadius:radius yRadius:radius];
-        [p setLineWidth:2];
-        [p stroke];
+        // Very subtle hover fill
+        [[NSColor.labelColor colorWithAlphaComponent:0.06] setFill];
+        [[NSBezierPath bezierPathWithRoundedRect:r xRadius:radius yRadius:radius] fill];
     }
     if (self.dotColors) {
         CGFloat sz = SizePref.cellSize;

--- a/Itsycal/MoCalendar.h
+++ b/Itsycal/MoCalendar.h
@@ -101,5 +101,9 @@ typedef enum : NSInteger {
 // - Otherwise, there are up to 3 dots with the given colors.
 - (NSArray<NSColor *> *)dotColorsForDate:(MoDate)date useColor:(BOOL)useColor;
 
+@optional
+// Called when the user drops an event (dragged from the agenda) onto a calendar cell.
+- (void)calendar:(MoCalendar *)cal didDropEventWithIdentifier:(NSString *)eventId onDate:(MoDate)date;
+
 @end
 

--- a/Itsycal/MoCalendar.m
+++ b/Itsycal/MoCalendar.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 mowglii.com. All rights reserved.
 //
 
+#import <QuartzCore/QuartzCore.h>
 #import "MoCalendar.h"
 #import "MoCalCell.h"
 #import "MoCalGrid.h"
@@ -35,6 +36,8 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
     NSColor *_highlightColor;
     MoCalResizeHandle *_resizeHandle;
     NSInteger _repeatCount;
+    CGFloat _scrollAccumulator;
+    NSTimeInterval _lastScrollMonthChange;
 }
 
 - (instancetype)initWithFrame:(NSRect)frameRect
@@ -88,6 +91,7 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
     numRows = MIN(MAX(numRows, 6), 10);
     
     _dateGrid = [[MoCalGrid alloc] initWithRows:numRows columns:7 horizontalMargin:6 verticalMargin:6];
+    _dateGrid.wantsLayer = YES;
     _weekGrid = [[MoCalGrid alloc] initWithRows:numRows columns:1 horizontalMargin:0 verticalMargin:6];
     _dowGrid  = [[MoCalGrid alloc] initWithRows:1 columns:7 horizontalMargin:6 verticalMargin:0];
 
@@ -121,6 +125,8 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleLocaleNotification:) name:NSCurrentLocaleDidChangeNotification object:nil];
 
+    [self registerForDraggedTypes:@[@"com.mowglii.itsycal.event"]];
+
     _weekStartDOW = 0;  // 0=Sunday, 1=Monday...
     _highlightedDOWs = DOWMaskNone;
     _showWeeks    = NO;
@@ -140,7 +146,7 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
 
 - (BOOL)isOpaque
 {
-    return YES;
+    return NO;
 }
 
 #pragma mark
@@ -607,6 +613,40 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
 
 - (void)scrollWheel:(NSEvent *)theEvent
 {
+    // Reset accumulator when scrolling ends.
+    if (theEvent.phase == NSEventPhaseEnded || theEvent.phase == NSEventPhaseCancelled) {
+        _scrollAccumulator = 0;
+        return;
+    }
+
+    // Handle vertical scroll for month navigation.
+    CGFloat deltaY = theEvent.scrollingDeltaY;
+    if (fabs(deltaY) > fabs(theEvent.scrollingDeltaX)) {
+        // Cooldown: ignore scroll deltas for 0.4s after a month change
+        // to prevent trackpad momentum from rapidly flipping months.
+        NSTimeInterval now = [NSProcessInfo processInfo].systemUptime;
+        if (now - _lastScrollMonthChange < 0.4) {
+            return;
+        }
+        _scrollAccumulator += deltaY;
+        if (_scrollAccumulator > 20) {
+            [self showPreviousMonth:nil];
+            _scrollAccumulator = 0;
+            _lastScrollMonthChange = now;
+            [[NSHapticFeedbackManager defaultPerformer]
+                performFeedbackPattern:NSHapticFeedbackPatternAlignment
+                 performanceTime:NSHapticFeedbackPerformanceTimeDefault];
+        } else if (_scrollAccumulator < -20) {
+            [self showNextMonth:nil];
+            _scrollAccumulator = 0;
+            _lastScrollMonthChange = now;
+            [[NSHapticFeedbackManager defaultPerformer]
+                performFeedbackPattern:NSHapticFeedbackPatternAlignment
+                 performanceTime:NSHapticFeedbackPerformanceTimeDefault];
+        }
+        return;
+    }
+
     // Left/right swipes change to previous/next months.
     if (theEvent.phase == NSEventPhaseBegan) {
         CGFloat dX = theEvent.scrollingDeltaX;
@@ -623,7 +663,61 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
             }];
         }
     }
-    [super scrollWheel:theEvent];
+}
+
+#pragma mark -
+#pragma mark Drag and drop
+
+- (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender
+{
+    NSPasteboard *pb = sender.draggingPasteboard;
+    if ([pb stringForType:@"com.mowglii.itsycal.event"]) {
+        return NSDragOperationMove;
+    }
+    return NSDragOperationNone;
+}
+
+- (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender
+{
+    NSPoint location = [_dateGrid convertPoint:[sender draggingLocation] fromView:nil];
+    MoCalCell *cell = [_dateGrid cellAtPoint:location];
+    if (cell && cell != _hoveredCell) {
+        _hoveredCell.isHovered = NO;
+        _hoveredCell = cell;
+        _hoveredCell.isHovered = YES;
+    }
+    return cell ? NSDragOperationMove : NSDragOperationNone;
+}
+
+- (void)draggingExited:(id<NSDraggingInfo>)sender
+{
+    _hoveredCell.isHovered = NO;
+    _hoveredCell = nil;
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender
+{
+    NSPasteboard *pb = sender.draggingPasteboard;
+    NSString *eventId = [pb stringForType:@"com.mowglii.itsycal.event"];
+    if (!eventId) return NO;
+
+    NSPoint location = [_dateGrid convertPoint:[sender draggingLocation] fromView:nil];
+    MoCalCell *cell = [_dateGrid cellAtPoint:location];
+    if (!cell) return NO;
+
+    _hoveredCell.isHovered = NO;
+    _hoveredCell = nil;
+
+    if ([self.delegate respondsToSelector:@selector(calendar:didDropEventWithIdentifier:onDate:)]) {
+        [self.delegate calendar:self didDropEventWithIdentifier:eventId onDate:cell.date];
+    }
+    return YES;
+}
+
+- (void)draggingEnded:(id<NSDraggingInfo>)sender
+{
+    _hoveredCell.isHovered = NO;
+    _hoveredCell = nil;
 }
 
 #pragma mark
@@ -701,6 +795,13 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
     
     if (CompareDates(monthDate, self.monthDate) != 0) {
         _monthDate = monthDate;
+
+        // Add a smooth crossfade transition when the month changes.
+        CATransition *transition = [CATransition animation];
+        transition.type = kCATransitionFade;
+        transition.duration = 0.15;
+        [_dateGrid.layer addAnimation:transition forKey:@"monthTransition"];
+
         [self updateCalendar];
         didChangeMonth = YES;
     }
@@ -773,9 +874,6 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
 
 - (void)drawRect:(NSRect)dirtyRect
 {
-    [Theme.mainBackgroundColor set];
-    NSRectFill(self.bounds);
-    
     CGFloat radius = SizePref.cellRadius + 3;
     CGFloat sz = SizePref.cellSize;
     if (self.highlightedDOWs) {
@@ -814,8 +912,8 @@ NSString * const kMoCalendarNumRows = @"MoCalendarNumRows";
     if (!self.doNotDrawOutlineAroundCurrentMonth) {
         NSBezierPath *outlinePath = [self bezierPathWithStartCell:_monthStartCell endCell:_monthEndCell radius:radius inset:0 useRects:NO];
 
-        [Theme.currentMonthOutlineColor set];
-        [outlinePath setLineWidth:1.5];
+        [[Theme.currentMonthOutlineColor colorWithAlphaComponent:0.15] set];
+        [outlinePath setLineWidth:1];
         [outlinePath stroke];
     }
 }

--- a/Itsycal/MoTableView.h
+++ b/Itsycal/MoTableView.h
@@ -14,6 +14,9 @@
 
 - (void)tableView:(nonnull MoTableView *)tableView didHoverOverRow:(NSInteger)row;
 
+@optional
+- (BOOL)tableView:(nonnull MoTableView *)tableView handleKeyDown:(nonnull NSEvent *)event;
+
 @end
 
 @interface MoTableView : NSTableView

--- a/Itsycal/MoTableView.m
+++ b/Itsycal/MoTableView.m
@@ -73,6 +73,16 @@
 // stackoverflow.com/a/30594427/111418
 - (void)drawContextMenuHighlightForRow:(NSInteger)row {}
 
+- (void)keyDown:(NSEvent *)theEvent
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:handleKeyDown:)]) {
+        if ([self.delegate tableView:self handleKeyDown:theEvent]) {
+            return;
+        }
+    }
+    [super keyDown:theEvent];
+}
+
 #pragma mark -
 #pragma mark NSTrackingArea
 

--- a/Itsycal/Sizer.m
+++ b/Itsycal/Sizer.m
@@ -27,6 +27,14 @@ Sizer *SizePref = nil;
     return shared;
 }
 
+- (void)setNilValueForKey:(NSString *)key {
+    if ([key isEqualToString:@"sizePreference"]) {
+        _sizePreference = SizePreferenceSmall;
+        return;
+    }
+    [super setNilValueForKey:key];
+}
+
 - (void)setSizePreference:(SizePreference)sizePreference {
     _sizePreference = sizePreference;
     // Post notification on the main thread because the selector,
@@ -48,7 +56,7 @@ Sizer *SizePref = nil;
 }
 
 - (CGFloat)cellSize {
-    return SML_MED_LRG(23, 28, 32);
+    return SML_MED_LRG(26, 32, 36);
 }
 
 - (CGFloat)cellTextFieldVerticalSpace {
@@ -60,7 +68,7 @@ Sizer *SizePref = nil;
 }
 
 - (CGFloat)cellRadius {
-    return SML_MED_LRG(2, 3, 4);
+    return SML_MED_LRG(5, 6, 7);
 }
 
 - (CGFloat)tooltipWidth {

--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -217,6 +217,10 @@
     else if (keyChar == 'j' && cmdFlag) {
         if (![_agendaVC clickFirstActiveZoomButton]) NSBeep();
     }
+    else if (keyChar == NSTabCharacter && noFlags) {
+        // Tab from calendar moves focus to the agenda table view.
+        [self.itsycalWindow makeFirstResponder:_agendaVC.tv];
+    }
     else {
         [super keyDown:theEvent];
     }
@@ -496,7 +500,7 @@
     _statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
     _statusItem.button.target = self;
     _statusItem.button.action = @selector(statusItemClicked:);
-    [_statusItem.button sendActionOn:NSEventMaskLeftMouseDown];
+    [_statusItem.button sendActionOn:NSEventMaskLeftMouseDown | NSEventMaskRightMouseDown];
     [(NSButtonCell *)_statusItem.button.cell setHighlightsBy:NSNoCellMask];
 
     // Remember item position in menubar. (@pskowronek (Github))
@@ -850,6 +854,15 @@
 
 - (void)statusItemClicked:(id)sender
 {
+    // Right-click: show context menu with Quit.
+    if ([NSApp currentEvent].type == NSEventTypeRightMouseDown) {
+        NSMenu *menu = [[NSMenu alloc] init];
+        [menu addItemWithTitle:NSLocalizedString(@"Quit Itsycal", @"") action:@selector(terminate:) keyEquivalent:@""];
+        _statusItem.menu = menu;
+        [_statusItem.button performClick:nil];
+        _statusItem.menu = nil;
+        return;
+    }
     // If there are multiple screens and Itsycal is showing
     // on one and the user clicks the menu item on another,
     // instead of a regular toggle, we want Itsycal to hide
@@ -910,7 +923,12 @@
 
 - (void)windowDidResize:(NSNotification *)notification
 {
-    [self positionItsycalWindow];
+    // Only reposition if the window is not yet visible (during initial show).
+    // While the window is visible, let it grow/shrink from its top-left point
+    // naturally, without jumping to re-center under the status item.
+    if (!([self.itsycalWindow occlusionState] & NSWindowOcclusionStateVisible)) {
+        [self positionItsycalWindow];
+    }
 }
 
 - (void)windowDidResignKey:(NSNotification *)notification
@@ -1033,6 +1051,37 @@
     }
 }
 
+- (void)agendaWantsToEditEvent:(EKEvent *)event
+{
+    // Close popover if it's already showing.
+    if (_newEventPopover.shown) {
+        [_newEventPopover close];
+    }
+
+    // Was prefs window open in the past and then hidden when
+    // app became inactive? This prevents it from reappearing.
+    [self.prefsWC close];
+
+    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+
+    if (!_newEventPopover) {
+        _newEventPopover = [NSPopover new];
+        _newEventPopover.animates = NO;
+        _newEventPopover.delegate = self;
+    }
+    EventViewController *eventVC = [EventViewController new];
+    eventVC.ec = _ec;
+    eventVC.enclosingPopover = _newEventPopover;
+    eventVC.cal = _nsCal;
+    eventVC.title = @"";
+    eventVC.calSelectedDate = event.startDate;
+    eventVC.editingEvent = event;
+
+    _newEventPopover.contentViewController = eventVC;
+    _newEventPopover.appearance = NSApp.effectiveAppearance;
+    [_newEventPopover showRelativeToRect:_btnAdd.bounds ofView:_btnAdd preferredEdge:NSRectEdgeMinX];
+}
+
 - (void)agendaShowCalendarAppAtDate:(NSDate *)date
 {
     [self showCalendarAppAtDate:date dayView:YES];
@@ -1040,7 +1089,17 @@
 
 - (CGFloat)agendaMaxPossibleHeight
 {
-    return NSHeight(_screenFrame) - NSHeight(_moCal.frame) - 140;
+    CGFloat screenH = NSHeight(_screenFrame);
+    // Hard limit: don't let window extend beyond the screen.
+    CGFloat screenLimit = screenH - NSHeight(_moCal.frame) - 140;
+    // Preferred limit: keep window compact (~60-65% of screen).
+    CGFloat compactLimit = screenH * 0.35;
+    return MIN(screenLimit, compactLimit);
+}
+
+- (void)agendaWantsToReturnFocusToCalendar
+{
+    [self.itsycalWindow makeFirstResponder:_moCal];
 }
 
 #pragma mark -
@@ -1074,6 +1133,14 @@
         case 2: return @[colors[0], colors[1]];
         case 3: return @[colors[0], colors[1], colors[2]];
         default: return nil;
+    }
+}
+
+- (void)calendar:(MoCalendar *)cal didDropEventWithIdentifier:(NSString *)eventId onDate:(MoDate)date
+{
+    BOOL success = [_ec moveEventWithIdentifier:eventId toDate:date];
+    if (!success) {
+        NSBeep();
     }
 }
 


### PR DESCRIPTION
This one's the big one - a visual refresh plus some features I've been wishing Itsycal had. Totally understand if this is too much at once or goes in a different direction than you'd like. Happy to adjust, split, or drop parts.

## Visual changes

- **Today cell**: filled rounded rect with the accent color + white text, matching how Apple Calendar marks today. Feels more modern than the outline.
- **Selected/hovered cells**: subtle filled backgrounds instead of stroke outlines.
- **Softer corners**: bumped cell radius and window corner radius. Small thing but it makes the whole window feel more at home on modern macOS.
- **Vibrancy**: window background uses `NSVisualEffectView` (Menu material) masked to the window shape, so the popup feels native alongside system menus.
- **Agenda color bars**: replaced the small event dots with vertical color bars on the left edge of each event row - easier to scan.
- **Cell sizing**: slightly larger cells for more breathing room and readability.
- **Lighter window border**: reduced to 20% alpha since the shadow does most of the work.

## New features

- **Scroll-wheel month navigation**: two-finger vertical scroll changes months. 0.4s cooldown prevents momentum from flying through months, and there's haptic feedback on each change.
- **Month transition animation**: 0.15s crossfade when changing months.
- **Keyboard navigation for agenda**: Tab to focus the event list, Up/Down to navigate, Return to open the popover, Escape to go back to the calendar.
- **Event editing**: pencil button in the event popover (or right-click → Edit) opens the event form pre-populated for editing. Added `updateEvent:span:error:` to EventCenter.
- **Drag-and-drop**: drag events from the agenda to calendar cells to reschedule. Only works on modifiable calendars.
- **Right-click quit**: right-click on the status item for a quick Quit option.

## Small fixes included

- Window no longer repositions while visible (was causing a jump on content resize).
- Compact agenda height cap at 35% of screen height.
- Month outline made subtler (1px at 15% alpha).

Standalone PR, no dependencies on other PRs.