### PR TITLE
Add missing KVO observer removals in dealloc

### DIFF
--- a/Itsycal/ViewController.m
+++ b/Itsycal/ViewController.m
@@ -52,6 +52,9 @@
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowMonthInIcon];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowDayOfWeekInIcon];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowDaysWithNoEventsInAgenda];
+    [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kShowMeetingIndicator];
+    [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kHideIcon];
+    [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kBaselineOffset];
     [[NSUserDefaults standardUserDefaults] removeObserver:self forKeyPath:kClockFormat];
 }
 


### PR DESCRIPTION
fileNotifications registers KVO observers for 9 key paths but dealloc only removed 6 of them. Added the 3 missing removals:

- kShowMeetingIndicator
- kHideIcon
- kBaselineOffset