### PR TITLE
perf: cache row heights to avoid repeated Auto Layout solves

### DIFF
--- a/Itsycal/AgendaViewController.m
+++ b/Itsycal/AgendaViewController.m
@@ -414,7 +414,10 @@ static NSString *kEventCellIdentifier = @"EventCell";
 - (CGFloat)tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row
 {
     [self ensureRowHeightsCached];
-    return _cachedRowHeights[row].doubleValue;
+    if (row < (NSInteger)_cachedRowHeights.count) {
+        return _cachedRowHeights[row].doubleValue;
+    }
+    return 0;
 }
 
 - (BOOL)tableView:(NSTableView *)tableView isGroupRow:(NSInteger)row


### PR DESCRIPTION
## Summary

- `viewDidLayout` calls `tableView:heightOfRow:` for every row on each layout pass, each time running `populateEventCell` + `fittingSize` (a full Auto Layout solve). With 7+ days of events that adds up quickly.
- Added a `_cachedRowHeights` array that computes once and invalidates on data reload, location toggle, or table width change.

## Test plan

- [ ] Open Itsycal with 7+ days of events showing
- [ ] Resize the window, toggle location display, change event days -- verify layout still looks correct
- [ ] Navigate months and confirm no visual regressions