### PR TITLE
perf: cache meeting URL detection results by event identifier

### DIFF
--- a/Itsycal/EventCenter.m
+++ b/Itsycal/EventCenter.m
@@ -384,9 +384,9 @@ static NSString *kSelectedCalendars = @"SelectedCalendars";
     // Check cache first to avoid expensive NSDataDetector runs.
     NSString *eventID = info.event.eventIdentifier;
     if (eventID) {
-        NSURL *cachedURL = _meetingURLCache[eventID];
-        if (cachedURL) {
-            info.zoomURL = [cachedURL isEqual:[NSNull null]] ? nil : cachedURL;
+        id cachedValue = _meetingURLCache[eventID];
+        if (cachedValue) {
+            info.zoomURL = [cachedValue isEqual:[NSNull null]] ? nil : cachedValue;
             return;
         }
     }


### PR DESCRIPTION
## Summary

- `checkForZoomURL:` runs `NSDataDetector` (expensive regex engine) on every `_filterEvents` call, re-scanning the same event text each time.
- Added an `NSMutableDictionary` cache keyed by event identifier that persists across filter passes and clears on `refetchAll`.

## Test plan

- [ ] Verify Zoom/Teams/Meet/etc. buttons still appear on events with meeting links
- [ ] Add a new event with a meeting URL -- confirm the button shows after refresh
- [ ] Delete an event with a meeting URL -- confirm no stale data after refetch